### PR TITLE
Add daily GSC snapshot cron job

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -203,7 +203,7 @@ The CI workflow splits build from tests to minimize E2E critical path:
 - Vite proxies `/api` and `/admin/api` requests to the backend
 - Pre-commit hooks run ESLint and Prettier via husky + lint-staged
 - Production runs in Docker containers: app, worker, nginx, cron, PostgreSQL, two Redis instances (cache + jobs)
-- Cron jobs: TMDB sync (every 2h), sitemap generation (daily 6 AM PT), movie seeding (weekly Sun 4 AM PT), find uncertain deaths (weekly Sun 5 AM PT)
+- Cron jobs: TMDB sync (every 2h), sitemap generation (daily 6 AM PT), GSC snapshot (daily 7 AM UTC), movie seeding (weekly Sun 4 AM PT), find uncertain deaths (weekly Sun 5 AM PT)
 
 ### Cache Invalidation
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -203,7 +203,7 @@ The CI workflow splits build from tests to minimize E2E critical path:
 - Vite proxies `/api` and `/admin/api` requests to the backend
 - Pre-commit hooks run ESLint and Prettier via husky + lint-staged
 - Production runs in Docker containers: app, worker, nginx, cron, PostgreSQL, two Redis instances (cache + jobs)
-- Cron jobs: TMDB sync (every 2h), sitemap generation (daily 6 AM PT), GSC snapshot (daily 7 AM UTC), movie seeding (weekly Sun 4 AM PT), find uncertain deaths (weekly Sun 5 AM PT)
+- Cron jobs: TMDB sync (every 2h), sitemap generation (daily 6 AM PT), GSC snapshot (daily 7 AM PT), movie seeding (weekly Sun 4 AM PT), find uncertain deaths (weekly Sun 5 AM PT)
 
 ### Cache Invalidation
 

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -137,6 +137,8 @@ services:
         0 4 * * 0 cd /app/server && node dist/scripts/seed-movies.js $(($(date +%Y)-1)) $(date +%Y) --count 500
         # Find uncertain deaths - weekly Sunday 5 AM PT
         0 5 * * 0 cd /app/server && node dist/scripts/find-uncertain-deaths.js 2>&1 | head -100
+        # GSC snapshot - daily at 7 AM UTC
+        0 7 * * * cd /app/server && node dist/scripts/capture-gsc-snapshot.js
         EOF
         # Strip leading spaces from heredoc (YAML adds 8 spaces)
         sed -i 's/^[[:space:]]*//' /tmp/crontab

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -137,7 +137,7 @@ services:
         0 4 * * 0 cd /app/server && node dist/scripts/seed-movies.js $(($(date +%Y)-1)) $(date +%Y) --count 500
         # Find uncertain deaths - weekly Sunday 5 AM PT
         0 5 * * 0 cd /app/server && node dist/scripts/find-uncertain-deaths.js 2>&1 | head -100
-        # GSC snapshot - daily at 7 AM UTC
+        # GSC snapshot - daily at 7 AM PT
         0 7 * * * cd /app/server && node dist/scripts/capture-gsc-snapshot.js
         EOF
         # Strip leading spaces from heredoc (YAML adds 8 spaces)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -188,6 +188,8 @@ services:
         0 4 * * 0 cd /app/server && node --require newrelic --import newrelic/esm-loader.mjs dist/scripts/seed-movies.js $(($(date +%Y)-1)) $(date +%Y) --count 500
         # Find uncertain deaths - weekly Sunday 5 AM PT
         0 5 * * 0 cd /app/server && node --require newrelic --import newrelic/esm-loader.mjs dist/scripts/find-uncertain-deaths.js 2>&1 | head -100
+        # GSC snapshot - daily at 7 AM UTC (after GSC data refreshes)
+        0 7 * * * cd /app/server && node --require newrelic --import newrelic/esm-loader.mjs dist/scripts/capture-gsc-snapshot.js
         EOF
         # Strip leading spaces from heredoc (YAML adds 8 spaces)
         sed -i 's/^[[:space:]]*//' /tmp/crontab

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -188,7 +188,7 @@ services:
         0 4 * * 0 cd /app/server && node --require newrelic --import newrelic/esm-loader.mjs dist/scripts/seed-movies.js $(($(date +%Y)-1)) $(date +%Y) --count 500
         # Find uncertain deaths - weekly Sunday 5 AM PT
         0 5 * * 0 cd /app/server && node --require newrelic --import newrelic/esm-loader.mjs dist/scripts/find-uncertain-deaths.js 2>&1 | head -100
-        # GSC snapshot - daily at 7 AM UTC (after GSC data refreshes)
+        # GSC snapshot - daily at 7 AM PT (after GSC data refreshes)
         0 7 * * * cd /app/server && node --require newrelic --import newrelic/esm-loader.mjs dist/scripts/capture-gsc-snapshot.js
         EOF
         # Strip leading spaces from heredoc (YAML adds 8 spaces)

--- a/server/package.json
+++ b/server/package.json
@@ -111,6 +111,8 @@
     "report:rating-coverage": "tsx scripts/report-rating-coverage.ts",
     "//coverage:snapshot": "Capture death detail coverage snapshot (daily cron job)",
     "coverage:snapshot": "tsx scripts/capture-coverage-snapshot.ts",
+    "//gsc:snapshot": "Capture Google Search Console snapshot (daily cron job)",
+    "gsc:snapshot": "tsx scripts/capture-gsc-snapshot.ts",
     "// === Death Info Management ===": "",
     "//fix:death-info": "Scan and fix suspicious death records",
     "fix:death-info": "tsx scripts/fix-bad-death-info.ts",

--- a/server/scripts/capture-gsc-snapshot.test.ts
+++ b/server/scripts/capture-gsc-snapshot.test.ts
@@ -1,20 +1,45 @@
 import { describe, it, expect } from "vitest"
-import { categorizeUrl } from "../src/lib/gsc-client.js"
+import { categorizeUrl, extractPathFromUrl } from "../src/lib/gsc-client.js"
 
 /**
  * Tests for the GSC snapshot capture script.
  *
  * The main runSnapshot function is an async Commander action that orchestrates
  * GSC API calls → writeGscSnapshot (already tested in admin-gsc-queries.test.ts)
- * → cronjob tracking. We test the page categorization logic here since it's
- * the script's primary transformation. The DB write logic is covered by
- * writeGscSnapshot tests.
+ * → cronjob tracking. We test the URL extraction and page categorization logic
+ * here since that's the script's primary transformation.
  */
 
 describe("capture-gsc-snapshot", () => {
+  describe("extractPathFromUrl", () => {
+    it("extracts pathname from full URLs", () => {
+      expect(extractPathFromUrl("https://deadonfilm.com/actor/john-wayne-4165")).toBe(
+        "/actor/john-wayne-4165"
+      )
+      expect(extractPathFromUrl("https://deadonfilm.com/movie/the-searchers-3114")).toBe(
+        "/movie/the-searchers-3114"
+      )
+    })
+
+    it("handles URLs with query params and fragments", () => {
+      expect(extractPathFromUrl("https://deadonfilm.com/search?q=test")).toBe("/search")
+      expect(extractPathFromUrl("https://deadonfilm.com/actor/foo#bio")).toBe("/actor/foo")
+    })
+
+    it("returns raw string for invalid URLs", () => {
+      expect(extractPathFromUrl("/actor/john-wayne-4165")).toBe("/actor/john-wayne-4165")
+      expect(extractPathFromUrl("not-a-url")).toBe("not-a-url")
+      expect(extractPathFromUrl("")).toBe("")
+    })
+  })
+
   describe("page categorization", () => {
     it("categorizes actor pages", () => {
       expect(categorizeUrl("/actor/john-wayne-4165")).toBe("actor")
+    })
+
+    it("categorizes actor death pages", () => {
+      expect(categorizeUrl("/actor/john-wayne-4165/death")).toBe("actor-death")
     })
 
     it("categorizes movie pages", () => {
@@ -25,13 +50,6 @@ describe("capture-gsc-snapshot", () => {
       expect(categorizeUrl("/show/breaking-bad-1396")).toBe("show")
     })
 
-    it("categorizes death pages", () => {
-      const result = categorizeUrl("/deaths")
-      // deaths may map to a specific category or "other" depending on implementation
-      expect(typeof result).toBe("string")
-      expect(result.length).toBeGreaterThan(0)
-    })
-
     it("categorizes the homepage", () => {
       expect(categorizeUrl("/")).toBe("home")
     })
@@ -39,6 +57,17 @@ describe("capture-gsc-snapshot", () => {
     it("categorizes unknown paths as other", () => {
       expect(categorizeUrl("/about")).toBe("other")
       expect(categorizeUrl("/faq")).toBe("other")
+    })
+  })
+
+  describe("end-to-end: full URL → page type", () => {
+    it("categorizes full GSC URLs via extractPathFromUrl + categorizeUrl", () => {
+      const categorize = (url: string) => categorizeUrl(extractPathFromUrl(url))
+
+      expect(categorize("https://deadonfilm.com/actor/helen-mirren-15854")).toBe("actor")
+      expect(categorize("https://deadonfilm.com/movie/fast-x-385687")).toBe("movie")
+      expect(categorize("https://deadonfilm.com/")).toBe("home")
+      expect(categorize("https://deadonfilm.com/about")).toBe("other")
     })
   })
 })

--- a/server/scripts/capture-gsc-snapshot.test.ts
+++ b/server/scripts/capture-gsc-snapshot.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "vitest"
+import { categorizeUrl } from "../src/lib/gsc-client.js"
+
+/**
+ * Tests for the GSC snapshot capture script.
+ *
+ * The main runSnapshot function is an async Commander action that orchestrates
+ * GSC API calls → writeGscSnapshot (already tested in admin-gsc-queries.test.ts)
+ * → cronjob tracking. We test the page categorization logic here since it's
+ * the script's primary transformation. The DB write logic is covered by
+ * writeGscSnapshot tests.
+ */
+
+describe("capture-gsc-snapshot", () => {
+  describe("page categorization", () => {
+    it("categorizes actor pages", () => {
+      expect(categorizeUrl("/actor/john-wayne-4165")).toBe("actor")
+    })
+
+    it("categorizes movie pages", () => {
+      expect(categorizeUrl("/movie/the-searchers-3114")).toBe("movie")
+    })
+
+    it("categorizes show pages", () => {
+      expect(categorizeUrl("/show/breaking-bad-1396")).toBe("show")
+    })
+
+    it("categorizes death pages", () => {
+      const result = categorizeUrl("/deaths")
+      // deaths may map to a specific category or "other" depending on implementation
+      expect(typeof result).toBe("string")
+      expect(result.length).toBeGreaterThan(0)
+    })
+
+    it("categorizes the homepage", () => {
+      expect(categorizeUrl("/")).toBe("home")
+    })
+
+    it("categorizes unknown paths as other", () => {
+      expect(categorizeUrl("/about")).toBe("other")
+      expect(categorizeUrl("/faq")).toBe("other")
+    })
+  })
+})

--- a/server/scripts/capture-gsc-snapshot.ts
+++ b/server/scripts/capture-gsc-snapshot.ts
@@ -1,0 +1,201 @@
+#!/usr/bin/env tsx
+/**
+ * Capture Google Search Console snapshot.
+ *
+ * Fetches search performance, top queries, top pages, page type performance,
+ * and indexing status from the GSC API and stores them in the database for
+ * historical tracking in the admin SEO metrics dashboard.
+ *
+ * Designed to run as a daily cron job. GSC data updates daily, so running
+ * more frequently provides no benefit.
+ *
+ * Usage:
+ *   cd server && npm run gsc:snapshot
+ */
+
+import "dotenv/config"
+import { Command } from "commander"
+import { getPool } from "../src/lib/db.js"
+import {
+  isGscConfigured,
+  getSearchPerformanceOverTime,
+  getTopQueries,
+  getTopPages,
+  getPerformanceByPageType,
+  getSitemaps,
+  categorizeUrl,
+  daysAgo,
+} from "../src/lib/gsc-client.js"
+import { logger } from "../src/lib/logger.js"
+import { startCronjobRun, completeCronjobRun } from "../src/lib/cronjob-tracking.js"
+import { withNewRelicTransaction } from "../src/lib/newrelic-cli.js"
+
+const program = new Command()
+  .name("capture-gsc-snapshot")
+  .description("Capture Google Search Console data for historical tracking")
+  .action(async () => {
+    await withNewRelicTransaction("capture-gsc-snapshot", async () => {
+      await runSnapshot()
+    })
+  })
+
+async function runSnapshot(): Promise<void> {
+  const pool = getPool()
+  let runId: number | undefined
+
+  try {
+    if (!isGscConfigured()) {
+      logger.warn("GSC not configured — skipping snapshot")
+      return
+    }
+
+    logger.info("Starting GSC snapshot capture")
+    runId = await startCronjobRun(pool, "gsc-snapshot")
+
+    const yesterday = daysAgo(1)
+    const thirtyDaysAgo = daysAgo(30)
+
+    // Fetch all data from GSC API
+    const performance = await getSearchPerformanceOverTime(thirtyDaysAgo, yesterday)
+    const queries = await getTopQueries(yesterday, yesterday, 100)
+    const pages = await getTopPages(yesterday, yesterday, 100)
+    const pageTypes = await getPerformanceByPageType(yesterday, yesterday)
+
+    let sitemaps: Awaited<ReturnType<typeof getSitemaps>>
+    try {
+      sitemaps = await getSitemaps()
+    } catch (sitemapError) {
+      logger.warn(
+        { error: sitemapError },
+        "Failed to fetch sitemaps — continuing without indexing data"
+      )
+      sitemaps = []
+    }
+
+    // Write atomically
+    const client = await pool.connect()
+    try {
+      await client.query("BEGIN")
+
+      // Search performance (last 30 days)
+      for (const row of performance.rows) {
+        await client.query(
+          `INSERT INTO gsc_search_performance (date, search_type, clicks, impressions, ctr, position)
+           VALUES ($1, $2, $3, $4, $5, $6)
+           ON CONFLICT (date, search_type)
+           DO UPDATE SET clicks = $3, impressions = $4, ctr = $5, position = $6, fetched_at = now()`,
+          [row.keys[0], "web", row.clicks, row.impressions, row.ctr, row.position]
+        )
+      }
+
+      // Top queries (yesterday)
+      for (const row of queries.rows) {
+        await client.query(
+          `INSERT INTO gsc_top_queries (date, query, clicks, impressions, ctr, position)
+           VALUES ($1, $2, $3, $4, $5, $6)
+           ON CONFLICT (date, query)
+           DO UPDATE SET clicks = $3, impressions = $4, ctr = $5, position = $6, fetched_at = now()`,
+          [yesterday, row.keys[0], row.clicks, row.impressions, row.ctr, row.position]
+        )
+      }
+
+      // Top pages (yesterday)
+      for (const row of pages.rows) {
+        const pageUrl = row.keys[0]
+        let path: string
+        try {
+          path = new URL(pageUrl).pathname
+        } catch {
+          path = pageUrl
+        }
+        const pageType = categorizeUrl(path)
+
+        await client.query(
+          `INSERT INTO gsc_top_pages (date, page_url, page_type, clicks, impressions, ctr, position)
+           VALUES ($1, $2, $3, $4, $5, $6, $7)
+           ON CONFLICT (date, page_url)
+           DO UPDATE SET page_type = $3, clicks = $4, impressions = $5, ctr = $6, position = $7, fetched_at = now()`,
+          [yesterday, pageUrl, pageType, row.clicks, row.impressions, row.ctr, row.position]
+        )
+      }
+
+      // Page type performance (yesterday)
+      for (const [pageType, data] of Object.entries(pageTypes)) {
+        await client.query(
+          `INSERT INTO gsc_page_type_performance (date, page_type, clicks, impressions, ctr, position)
+           VALUES ($1, $2, $3, $4, $5, $6)
+           ON CONFLICT (date, page_type)
+           DO UPDATE SET clicks = $3, impressions = $4, ctr = $5, position = $6, fetched_at = now()`,
+          [yesterday, pageType, data.clicks, data.impressions, data.ctr, data.position]
+        )
+      }
+
+      // Indexing status from sitemaps
+      if (sitemaps.length > 0) {
+        let totalSubmitted = 0
+        let totalIndexed = 0
+        const indexDetails: Record<string, { submitted: number; indexed: number }> = {}
+
+        for (const sitemap of sitemaps) {
+          for (const content of sitemap.contents) {
+            totalSubmitted += content.submitted
+            totalIndexed += content.indexed
+            if (!indexDetails[content.type]) {
+              indexDetails[content.type] = { submitted: 0, indexed: 0 }
+            }
+            indexDetails[content.type].submitted += content.submitted
+            indexDetails[content.type].indexed += content.indexed
+          }
+        }
+
+        await client.query(
+          `INSERT INTO gsc_indexing_status (date, total_submitted, total_indexed, index_details)
+           VALUES ($1, $2, $3, $4)
+           ON CONFLICT (date)
+           DO UPDATE SET total_submitted = $2, total_indexed = $3, index_details = $4, fetched_at = now()`,
+          [yesterday, totalSubmitted, totalIndexed, JSON.stringify(indexDetails)]
+        )
+      }
+
+      await client.query("COMMIT")
+
+      logger.info(
+        {
+          performanceDays: performance.rows.length,
+          queries: queries.rows.length,
+          pages: pages.rows.length,
+          pageTypes: Object.keys(pageTypes).length,
+        },
+        "GSC snapshot captured successfully"
+      )
+    } catch (txError) {
+      await client.query("ROLLBACK")
+      throw txError
+    } finally {
+      client.release()
+    }
+
+    await completeCronjobRun(pool, runId, "success")
+  } catch (error) {
+    logger.error({ error }, "Failed to capture GSC snapshot")
+
+    if (runId !== undefined) {
+      try {
+        await completeCronjobRun(
+          pool,
+          runId,
+          "failure",
+          error instanceof Error ? error.message : String(error)
+        )
+      } catch (trackingError) {
+        logger.error({ trackingError }, "Failed to record cronjob failure")
+      }
+    }
+
+    process.exitCode = 1
+  } finally {
+    await pool.end()
+  }
+}
+
+program.parse()

--- a/server/scripts/capture-gsc-snapshot.ts
+++ b/server/scripts/capture-gsc-snapshot.ts
@@ -88,7 +88,8 @@ async function runSnapshot(): Promise<void> {
         )
       }
 
-      // Top queries (yesterday)
+      // Top queries (yesterday) — delete stale rows first so re-runs don't accumulate beyond N
+      await client.query(`DELETE FROM gsc_top_queries WHERE date = $1`, [yesterday])
       for (const row of queries.rows) {
         await client.query(
           `INSERT INTO gsc_top_queries (date, query, clicks, impressions, ctr, position)
@@ -99,7 +100,8 @@ async function runSnapshot(): Promise<void> {
         )
       }
 
-      // Top pages (yesterday)
+      // Top pages (yesterday) — delete stale rows first so re-runs don't accumulate beyond N
+      await client.query(`DELETE FROM gsc_top_pages WHERE date = $1`, [yesterday])
       for (const row of pages.rows) {
         const pageUrl = row.keys[0]
         let path: string

--- a/server/scripts/capture-gsc-snapshot.ts
+++ b/server/scripts/capture-gsc-snapshot.ts
@@ -24,6 +24,7 @@ import {
   getPerformanceByPageType,
   getSitemaps,
   categorizeUrl,
+  extractPathFromUrl,
   daysAgo,
 } from "../src/lib/gsc-client.js"
 import { writeGscSnapshot, type GscPageRow } from "../src/lib/db/admin-gsc-queries.js"
@@ -53,15 +54,9 @@ function categorizePages(
 ): GscPageRow[] {
   return rows.map((row) => {
     const pageUrl = row.keys[0]
-    let path: string
-    try {
-      path = new URL(pageUrl).pathname
-    } catch {
-      path = pageUrl
-    }
     return {
       page_url: pageUrl,
-      page_type: categorizeUrl(path),
+      page_type: categorizeUrl(extractPathFromUrl(pageUrl)),
       clicks: row.clicks,
       impressions: row.impressions,
       ctr: row.ctr,

--- a/server/scripts/capture-gsc-snapshot.ts
+++ b/server/scripts/capture-gsc-snapshot.ts
@@ -26,7 +26,9 @@ import {
   categorizeUrl,
   daysAgo,
 } from "../src/lib/gsc-client.js"
+import { writeGscSnapshot, type GscPageRow } from "../src/lib/db/admin-gsc-queries.js"
 import { logger } from "../src/lib/logger.js"
+import { invalidateByPattern } from "../src/lib/cache.js"
 import { startCronjobRun, completeCronjobRun } from "../src/lib/cronjob-tracking.js"
 import { withNewRelicTransaction } from "../src/lib/newrelic-cli.js"
 
@@ -39,6 +41,35 @@ const program = new Command()
     })
   })
 
+/** Categorize raw GSC page rows into typed page rows with page_type. */
+function categorizePages(
+  rows: Array<{
+    keys: string[]
+    clicks: number
+    impressions: number
+    ctr: number
+    position: number
+  }>
+): GscPageRow[] {
+  return rows.map((row) => {
+    const pageUrl = row.keys[0]
+    let path: string
+    try {
+      path = new URL(pageUrl).pathname
+    } catch {
+      path = pageUrl
+    }
+    return {
+      page_url: pageUrl,
+      page_type: categorizeUrl(path),
+      clicks: row.clicks,
+      impressions: row.impressions,
+      ctr: row.ctr,
+      position: row.position,
+    }
+  })
+}
+
 async function runSnapshot(): Promise<void> {
   const pool = getPool()
   let runId: number | undefined
@@ -50,6 +81,13 @@ async function runSnapshot(): Promise<void> {
     }
 
     logger.info("Starting GSC snapshot capture")
+
+    // Clear GSC cache so we get fresh data from the API, not stale Redis entries
+    const cleared = await invalidateByPattern("gsc:*")
+    if (cleared > 0) {
+      logger.info({ cleared }, "Cleared stale GSC cache entries")
+    }
+
     runId = await startCronjobRun(pool, "gsc-snapshot")
 
     const yesterday = daysAgo(1)
@@ -58,7 +96,7 @@ async function runSnapshot(): Promise<void> {
     // Fetch all data from GSC API
     const performance = await getSearchPerformanceOverTime(thirtyDaysAgo, yesterday)
     const queries = await getTopQueries(yesterday, yesterday, 100)
-    const pages = await getTopPages(yesterday, yesterday, 100)
+    const rawPages = await getTopPages(yesterday, yesterday, 100)
     const pageTypes = await getPerformanceByPageType(yesterday, yesterday)
 
     let sitemaps: Awaited<ReturnType<typeof getSitemaps>>
@@ -77,99 +115,17 @@ async function runSnapshot(): Promise<void> {
     try {
       await client.query("BEGIN")
 
-      // Search performance (last 30 days)
-      for (const row of performance.rows) {
-        await client.query(
-          `INSERT INTO gsc_search_performance (date, search_type, clicks, impressions, ctr, position)
-           VALUES ($1, $2, $3, $4, $5, $6)
-           ON CONFLICT (date, search_type)
-           DO UPDATE SET clicks = $3, impressions = $4, ctr = $5, position = $6, fetched_at = now()`,
-          [row.keys[0], "web", row.clicks, row.impressions, row.ctr, row.position]
-        )
-      }
-
-      // Top queries (yesterday) — delete stale rows first so re-runs don't accumulate beyond N
-      await client.query(`DELETE FROM gsc_top_queries WHERE date = $1`, [yesterday])
-      for (const row of queries.rows) {
-        await client.query(
-          `INSERT INTO gsc_top_queries (date, query, clicks, impressions, ctr, position)
-           VALUES ($1, $2, $3, $4, $5, $6)
-           ON CONFLICT (date, query)
-           DO UPDATE SET clicks = $3, impressions = $4, ctr = $5, position = $6, fetched_at = now()`,
-          [yesterday, row.keys[0], row.clicks, row.impressions, row.ctr, row.position]
-        )
-      }
-
-      // Top pages (yesterday) — delete stale rows first so re-runs don't accumulate beyond N
-      await client.query(`DELETE FROM gsc_top_pages WHERE date = $1`, [yesterday])
-      for (const row of pages.rows) {
-        const pageUrl = row.keys[0]
-        let path: string
-        try {
-          path = new URL(pageUrl).pathname
-        } catch {
-          path = pageUrl
-        }
-        const pageType = categorizeUrl(path)
-
-        await client.query(
-          `INSERT INTO gsc_top_pages (date, page_url, page_type, clicks, impressions, ctr, position)
-           VALUES ($1, $2, $3, $4, $5, $6, $7)
-           ON CONFLICT (date, page_url)
-           DO UPDATE SET page_type = $3, clicks = $4, impressions = $5, ctr = $6, position = $7, fetched_at = now()`,
-          [yesterday, pageUrl, pageType, row.clicks, row.impressions, row.ctr, row.position]
-        )
-      }
-
-      // Page type performance (yesterday)
-      for (const [pageType, data] of Object.entries(pageTypes)) {
-        await client.query(
-          `INSERT INTO gsc_page_type_performance (date, page_type, clicks, impressions, ctr, position)
-           VALUES ($1, $2, $3, $4, $5, $6)
-           ON CONFLICT (date, page_type)
-           DO UPDATE SET clicks = $3, impressions = $4, ctr = $5, position = $6, fetched_at = now()`,
-          [yesterday, pageType, data.clicks, data.impressions, data.ctr, data.position]
-        )
-      }
-
-      // Indexing status from sitemaps
-      if (sitemaps.length > 0) {
-        let totalSubmitted = 0
-        let totalIndexed = 0
-        const indexDetails: Record<string, { submitted: number; indexed: number }> = {}
-
-        for (const sitemap of sitemaps) {
-          for (const content of sitemap.contents) {
-            totalSubmitted += content.submitted
-            totalIndexed += content.indexed
-            if (!indexDetails[content.type]) {
-              indexDetails[content.type] = { submitted: 0, indexed: 0 }
-            }
-            indexDetails[content.type].submitted += content.submitted
-            indexDetails[content.type].indexed += content.indexed
-          }
-        }
-
-        await client.query(
-          `INSERT INTO gsc_indexing_status (date, total_submitted, total_indexed, index_details)
-           VALUES ($1, $2, $3, $4)
-           ON CONFLICT (date)
-           DO UPDATE SET total_submitted = $2, total_indexed = $3, index_details = $4, fetched_at = now()`,
-          [yesterday, totalSubmitted, totalIndexed, JSON.stringify(indexDetails)]
-        )
-      }
+      const result = await writeGscSnapshot(client, {
+        yesterday,
+        performance,
+        queries,
+        pages: categorizePages(rawPages.rows),
+        pageTypes,
+        sitemaps,
+      })
 
       await client.query("COMMIT")
-
-      logger.info(
-        {
-          performanceDays: performance.rows.length,
-          queries: queries.rows.length,
-          pages: pages.rows.length,
-          pageTypes: Object.keys(pageTypes).length,
-        },
-        "GSC snapshot captured successfully"
-      )
+      logger.info(result, "GSC snapshot captured successfully")
     } catch (txError) {
       await client.query("ROLLBACK")
       throw txError

--- a/server/src/lib/gsc-client.ts
+++ b/server/src/lib/gsc-client.ts
@@ -269,8 +269,6 @@ export async function getPerformanceByPageType(
     rowLimit: 5000,
   })
 
-  const siteUrl = getSiteUrl().replace(/\/$/, "")
-
   // Categorize pages by URL pattern
   const categories: Record<
     string,

--- a/server/src/lib/gsc-client.ts
+++ b/server/src/lib/gsc-client.ts
@@ -279,12 +279,7 @@ export async function getPerformanceByPageType(
 
   for (const row of result.rows) {
     const url = row.keys[0] || ""
-    let path: string
-    try {
-      path = new URL(url).pathname
-    } catch {
-      path = url.replace(siteUrl, "")
-    }
+    const path = extractPathFromUrl(url)
     const category = categorizeUrl(path)
 
     if (!categories[category]) {
@@ -313,6 +308,18 @@ export async function getPerformanceByPageType(
   }
 
   return output
+}
+
+/**
+ * Extract the pathname from a URL string.
+ * Falls back to the raw string on parse failure.
+ */
+export function extractPathFromUrl(url: string): string {
+  try {
+    return new URL(url).pathname
+  } catch {
+    return url
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary

- New script captures Google Search Console data daily into the `gsc_*` database tables
- Populates the admin SEO metrics dashboard (`/admin/analytics?tab=seo-metrics`) automatically
- Runs daily at 7 AM UTC via supercronic (after GSC data refreshes)

## Changes

- `server/scripts/capture-gsc-snapshot.ts` — CLI script that fetches search performance (30 days), top queries, top pages, page type performance, and indexing status from GSC API, writes atomically to DB
- `server/package.json` — adds `gsc:snapshot` npm script
- `docker-compose.yml` / `docker-compose.test.yml` — adds cron entry in both environments
- `CLAUDE.md` — documents the new cron job

## Design notes

- Gracefully handles sitemap fetch failures (continues saving other data)
- Uses cronjob-tracking for run monitoring in admin dashboard
- All DB writes use `ON CONFLICT ... DO UPDATE` (idempotent, safe to re-run)
- Follows same pattern as existing `capture-coverage-snapshot.ts`

## Test plan

- [x] Server type-check passes
- [x] Lint passes (prettier ran via pre-commit hook)
- [ ] Manual run: `cd server && npm run gsc:snapshot` (requires GSC credentials)

🤖 Generated with [Claude Code](https://claude.com/claude-code)