### PR TITLE
Fix empty lesser-known facts from stale cached responses

### DIFF
--- a/.claude/rules/migrations.md
+++ b/.claude/rules/migrations.md
@@ -33,6 +33,25 @@ ls server/migrations/ | cut -d'_' -f1 | sort | uniq -d
 # Should output nothing - any output means duplicate timestamps exist
 ```
 
+## Cache Compatibility for Schema Changes
+
+**When a migration changes the shape of a cached column** (e.g., `text[]` → `jsonb` objects, adding/removing fields from a JSON column), the Redis cache will still serve the old format until TTL expires. This causes frontend bugs when the code expects the new shape.
+
+**Required steps:**
+
+1. **Make the frontend resilient to both formats.** Add a normalizer function that accepts either the old or new shape and returns the new shape. This is the primary defense — cache flushes can fail or miss keys.
+
+2. **Flush affected cache keys in the migration or a post-migration script.** Use `invalidateActorCache(actorId)` for actor data, or pattern-based deletion for broader caches.
+
+3. **Document the format change** in the migration file's JSDoc comment so future developers know both formats existed.
+
+```typescript
+// Example: normalizer for text[] → {text, sourceUrl, sourceName}[]
+function normalizeFact(fact: string | { text: string }) {
+  return typeof fact === "string" ? { text: fact, sourceUrl: null, sourceName: null } : fact
+}
+```
+
 ## JavaScript/CommonJS Files
 
 These must remain JS for tooling: `eslint.config.js`, `postcss.config.js`, `tailwind.config.js`, `server/migrations/*.cjs`, `server/newrelic.cjs`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -221,6 +221,8 @@ The `invalidateActorCache(actorId)` function in `server/src/lib/cache.ts` handle
 
 **Do not** use `curl` to verify data after cache invalidation — that re-populates the cache. Instead use `redis-cli GET` to inspect the cache or query the database directly.
 
+**When a migration changes the shape of a cached column** (e.g., `text[]` → JSONB objects), the Redis cache still serves the old format until TTL expires. This causes frontend bugs when code expects the new shape. **Always** make the frontend resilient to both old and new formats with a normalizer function, and flush affected cache keys in the migration or a post-migration script.
+
 ## JavaScript/CommonJS Files
 
 These must remain JS/CJS for tooling compatibility: `eslint.config.js`, `postcss.config.js`, `tailwind.config.js`, `server/migrations/*.cjs`, `server/newrelic.cjs`

--- a/src/pages/ActorPage.test.tsx
+++ b/src/pages/ActorPage.test.tsx
@@ -937,5 +937,33 @@ describe("ActorPage", () => {
       // https: URL should render as a link
       expect(screen.getByLabelText("Source: Safe (opens in new tab)")).toBeInTheDocument()
     })
+
+    it("renders plain string facts from stale cached responses", async () => {
+      // Old cached responses have lesserKnownFacts as string[], not object[]
+      // The normalizeFact function should handle both formats
+      mockActorWithFacts([
+        "He owned more than 50 bicycles" as unknown as (typeof factsData)[0],
+        "He was a trained mime" as unknown as (typeof factsData)[0],
+        { text: "A normal object fact", sourceUrl: null, sourceName: null },
+      ])
+
+      renderWithProviders(<ActorPage />)
+
+      await waitFor(() => {
+        expect(screen.getByTestId("biography-facts")).toBeInTheDocument()
+      })
+
+      // String facts should render their text content
+      expect(screen.getByText("He owned more than 50 bicycles")).toBeInTheDocument()
+      expect(screen.getByText("He was a trained mime")).toBeInTheDocument()
+      // Object fact should also render
+      expect(screen.getByText("A normal object fact")).toBeInTheDocument()
+      // No empty bullets — all 3 facts should have text
+      const items = screen.getByTestId("biography-facts").querySelectorAll("li")
+      expect(items).toHaveLength(3)
+      items.forEach((item) => {
+        expect(item.textContent!.trim().length).toBeGreaterThan(1) // more than just the bullet
+      })
+    })
   })
 })

--- a/src/pages/ActorPage.test.tsx
+++ b/src/pages/ActorPage.test.tsx
@@ -941,11 +941,12 @@ describe("ActorPage", () => {
     it("renders plain string facts from stale cached responses", async () => {
       // Old cached responses have lesserKnownFacts as string[], not object[]
       // The normalizeFact function should handle both formats
-      mockActorWithFacts([
-        "He owned more than 50 bicycles" as unknown as (typeof factsData)[0],
-        "He was a trained mime" as unknown as (typeof factsData)[0],
+      const staleCachedFacts: Array<string | (typeof factsData)[0]> = [
+        "He owned more than 50 bicycles",
+        "He was a trained mime",
         { text: "A normal object fact", sourceUrl: null, sourceName: null },
-      ])
+      ]
+      mockActorWithFacts(staleCachedFacts as unknown as typeof factsData)
 
       renderWithProviders(<ActorPage />)
 

--- a/src/pages/ActorPage.tsx
+++ b/src/pages/ActorPage.tsx
@@ -158,9 +158,9 @@ function isSafeUrl(url: string): boolean {
 }
 
 /** Normalize a fact that may be a plain string (old cached format) or structured object. */
-function normalizeFact(
-  fact: string | { text: string; sourceUrl: string | null; sourceName: string | null }
-): { text: string; sourceUrl: string | null; sourceName: string | null } {
+type LesserKnownFact = BiographyDetails["lesserKnownFacts"][number]
+
+function normalizeFact(fact: string | LesserKnownFact): LesserKnownFact {
   if (typeof fact === "string") return { text: fact, sourceUrl: null, sourceName: null }
   return fact
 }

--- a/src/pages/ActorPage.tsx
+++ b/src/pages/ActorPage.tsx
@@ -157,10 +157,19 @@ function isSafeUrl(url: string): boolean {
   }
 }
 
+/** Normalize a fact that may be a plain string (old cached format) or structured object. */
+function normalizeFact(
+  fact: string | { text: string; sourceUrl: string | null; sourceName: string | null }
+): { text: string; sourceUrl: string | null; sourceName: string | null } {
+  if (typeof fact === "string") return { text: fact, sourceUrl: null, sourceName: null }
+  return fact
+}
+
 function LesserKnownFacts({ facts }: { facts: BiographyDetails["lesserKnownFacts"] }) {
   const [showAll, setShowAll] = useState(false)
-  const visibleFacts = showAll ? facts : facts.slice(0, INITIAL_FACTS_SHOWN)
-  const hiddenCount = facts.length - INITIAL_FACTS_SHOWN
+  const normalizedFacts = facts.map(normalizeFact)
+  const visibleFacts = showAll ? normalizedFacts : normalizedFacts.slice(0, INITIAL_FACTS_SHOWN)
+  const hiddenCount = normalizedFacts.length - INITIAL_FACTS_SHOWN
 
   return (
     <div className="mb-6 rounded-lg bg-surface-elevated p-4" data-testid="biography-facts">


### PR DESCRIPTION
## Summary

- Lesser-known facts showing as empty bullets on actor pages (e.g., Robin Williams)
- Root cause: migration from `text[]` to JSONB objects left stale Redis cache entries with the old string format
- Frontend was rendering `fact.text` on a plain string (which is `undefined`), producing empty bullet points

## Changes

- Added `normalizeFact()` helper that handles both string and object formats
- Facts from stale cached responses (plain strings) are wrapped in `{text, sourceUrl: null, sourceName: null}` before rendering
- New cache entries from the database are already in the correct JSONB format — this is purely a backwards-compatibility shim for TTL expiry

## Test Plan

- [x] All 37 ActorPage tests pass
- [x] Verified stale Redis cache for Robin Williams has old string format
- [x] Verified database has correct JSONB format
- [ ] Manual: check deadonfilm.com/actor/robin-williams-7468 after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)