### PR TITLE
Extract shared Claude JSON helper with prefill and jsonrepair

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -155,6 +155,16 @@ it("returns cached data on cache hit", async () => {
 })
 ```
 
+## Diagnosing Test Failures
+
+When a test run reports failures, **do not re-run the full suite just to find the failing test name**. The failure information is already in the output. Either:
+
+1. **Capture output with `tee`** so you can search it: `npm test 2>&1 | tee /tmp/test-output.txt | tail -5` then `grep "FAIL\|×" /tmp/test-output.txt`
+2. **Use `grep` on the same run**: `npm test 2>&1 | grep -E "FAIL|×"` to extract just the failing test names
+3. **Run only the suspected file** directly: `npx vitest run path/to/suspected.test.ts`
+
+Never run 300 test files a second time when the first run already told you which one failed.
+
 ## Avoid Unused Variables
 
 Remove unused variables before committing, especially in tests:

--- a/docs/superpowers/plans/2026-04-06-shared-claude-json.md
+++ b/docs/superpowers/plans/2026-04-06-shared-claude-json.md
@@ -1,0 +1,545 @@
+# Shared Claude JSON Helper Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extract a shared helper for calling Claude and parsing JSON responses, replacing duplicated SDK+parsing code in both enrichment systems with a single reliable pipeline that includes assistant prefill and jsonrepair.
+
+**Architecture:** New `callClaudeForJson()` in `server/src/lib/shared/claude-json.ts` handles Anthropic SDK call with `{` prefill, text extraction, fence stripping, jsonrepair, and JSON.parse. Both `biography-sources/claude-cleanup.ts` and `death-sources/claude-cleanup.ts` call it instead of managing their own pipelines. Callers keep cost computation, New Relic instrumentation, and domain-specific validation.
+
+**Tech Stack:** TypeScript, @anthropic-ai/sdk, jsonrepair, vitest
+
+---
+
+### Task 1: Create shared claude-json helper with tests
+
+**Files:**
+- Create: `server/src/lib/shared/claude-json.ts`
+- Create: `server/src/lib/shared/claude-json.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `server/src/lib/shared/claude-json.test.ts`:
+
+```typescript
+import { describe, it, expect, vi } from "vitest"
+import { callClaudeForJson } from "./claude-json.js"
+
+// Minimal mock Anthropic client
+function mockClient(textResponse: string, tokens?: { input?: number; output?: number }) {
+  return {
+    messages: {
+      create: vi.fn().mockResolvedValue({
+        content: [{ type: "text", text: textResponse }],
+        usage: {
+          input_tokens: tokens?.input ?? 100,
+          output_tokens: tokens?.output ?? 50,
+        },
+      }),
+    },
+  } as any
+}
+
+function mockClientNoText() {
+  return {
+    messages: {
+      create: vi.fn().mockResolvedValue({
+        content: [{ type: "image", source: {} }],
+        usage: { input_tokens: 100, output_tokens: 0 },
+      }),
+    },
+  } as any
+}
+
+function mockClientError(error: Error) {
+  return {
+    messages: {
+      create: vi.fn().mockRejectedValue(error),
+    },
+  } as any
+}
+
+describe("callClaudeForJson", () => {
+  const opts = { model: "claude-sonnet-4-20250514", maxTokens: 1024, prompt: "Return JSON" }
+
+  it("parses valid JSON response (prefill prepends opening brace)", async () => {
+    // Claude's response omits the leading { because assistant prefill provides it
+    const client = mockClient('"name": "John", "age": 30}')
+    const result = await callClaudeForJson(client, opts)
+
+    expect(result.data).toEqual({ name: "John", age: 30 })
+    expect(result.error).toBeUndefined()
+    expect(result.inputTokens).toBe(100)
+    expect(result.outputTokens).toBe(50)
+  })
+
+  it("sends assistant prefill in messages", async () => {
+    const client = mockClient('"ok": true}')
+    await callClaudeForJson(client, opts)
+
+    const call = client.messages.create.mock.calls[0][0]
+    expect(call.messages).toEqual([
+      { role: "user", content: "Return JSON" },
+      { role: "assistant", content: "{" },
+    ])
+    expect(call.model).toBe("claude-sonnet-4-20250514")
+    expect(call.max_tokens).toBe(1024)
+  })
+
+  it("passes system parameter when provided", async () => {
+    const client = mockClient('"ok": true}')
+    await callClaudeForJson(client, { ...opts, system: "You are a JSON bot" })
+
+    const call = client.messages.create.mock.calls[0][0]
+    expect(call.system).toBe("You are a JSON bot")
+  })
+
+  it("omits system parameter when not provided", async () => {
+    const client = mockClient('"ok": true}')
+    await callClaudeForJson(client, opts)
+
+    const call = client.messages.create.mock.calls[0][0]
+    expect(call.system).toBeUndefined()
+  })
+
+  it("strips markdown code fences before parsing", async () => {
+    // Response wrapped in fences, without leading { (prefill provides it)
+    const client = mockClient('```json\n"narrative": "test"}\n```')
+    const result = await callClaudeForJson(client, opts)
+
+    expect(result.data).toEqual({ narrative: "test" })
+    expect(result.error).toBeUndefined()
+  })
+
+  it("repairs minor JSON issues via jsonrepair", async () => {
+    // Trailing comma — invalid JSON but fixable by jsonrepair
+    const client = mockClient('"name": "John", "age": 30,}')
+    const result = await callClaudeForJson(client, opts)
+
+    expect(result.data).toEqual({ name: "John", age: 30 })
+    expect(result.error).toBeUndefined()
+  })
+
+  it("returns error when no text block in response", async () => {
+    const client = mockClientNoText()
+    const result = await callClaudeForJson(client, opts)
+
+    expect(result.data).toBeNull()
+    expect(result.error).toBe("No text response from Claude")
+    expect(result.inputTokens).toBe(100)
+    expect(result.outputTokens).toBe(0)
+  })
+
+  it("returns error when response is completely unparseable", async () => {
+    const client = mockClient("Looking at the sources, I can see that...")
+    const result = await callClaudeForJson(client, opts)
+
+    expect(result.data).toBeNull()
+    expect(result.error).toContain("Failed to parse")
+    expect(result.inputTokens).toBe(100)
+    expect(result.outputTokens).toBe(50)
+  })
+
+  it("returns error when API call fails", async () => {
+    const client = mockClientError(new Error("Rate limit exceeded"))
+    const result = await callClaudeForJson(client, opts)
+
+    expect(result.data).toBeNull()
+    expect(result.error).toBe("Claude API error: Rate limit exceeded")
+    expect(result.inputTokens).toBe(0)
+    expect(result.outputTokens).toBe(0)
+  })
+
+  it("returns token counts from response usage", async () => {
+    const client = mockClient('"ok": true}', { input: 3000, output: 1200 })
+    const result = await callClaudeForJson(client, opts)
+
+    expect(result.inputTokens).toBe(3000)
+    expect(result.outputTokens).toBe(1200)
+  })
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd server && npx vitest run src/lib/shared/claude-json.test.ts`
+Expected: FAIL — module not found
+
+- [ ] **Step 3: Implement the helper**
+
+Create `server/src/lib/shared/claude-json.ts`:
+
+```typescript
+/**
+ * Shared helper for calling Claude and parsing JSON responses.
+ *
+ * Handles the full pipeline: API call with assistant prefill, text extraction,
+ * markdown fence stripping, jsonrepair, and JSON.parse. Used by both biography
+ * and death enrichment synthesis.
+ *
+ * Never throws — returns { data: null, error } on failure.
+ */
+
+import type Anthropic from "@anthropic-ai/sdk"
+import { stripMarkdownCodeFences } from "../claude-batch/response-parser.js"
+import { jsonrepair } from "jsonrepair"
+
+export interface ClaudeJsonResult<T> {
+  data: T | null
+  inputTokens: number
+  outputTokens: number
+  error?: string
+}
+
+export async function callClaudeForJson<T = Record<string, unknown>>(
+  client: Anthropic,
+  options: {
+    model: string
+    maxTokens: number
+    prompt: string
+    system?: string
+  }
+): Promise<ClaudeJsonResult<T>> {
+  const { model, maxTokens, prompt, system } = options
+
+  // Call Claude with assistant prefill to force JSON output
+  let response: Anthropic.Message
+  try {
+    response = await client.messages.create({
+      model,
+      max_tokens: maxTokens,
+      messages: [
+        { role: "user", content: prompt },
+        { role: "assistant", content: "{" },
+      ],
+      ...(system !== undefined && { system }),
+    })
+  } catch (error) {
+    return {
+      data: null,
+      inputTokens: 0,
+      outputTokens: 0,
+      error: `Claude API error: ${error instanceof Error ? error.message : "Unknown error"}`,
+    }
+  }
+
+  const inputTokens = response.usage.input_tokens
+  const outputTokens = response.usage.output_tokens
+
+  // Extract text block
+  const textBlock = response.content.find((block) => block.type === "text")
+  if (!textBlock || textBlock.type !== "text") {
+    return {
+      data: null,
+      inputTokens,
+      outputTokens,
+      error: "No text response from Claude",
+    }
+  }
+
+  // Parse JSON: strip fences, prepend { from prefill, repair, parse
+  try {
+    const stripped = stripMarkdownCodeFences(textBlock.text.trim())
+    const withBrace = "{" + stripped
+    const repaired = jsonrepair(withBrace)
+    const parsed = JSON.parse(repaired) as T
+    return { data: parsed, inputTokens, outputTokens }
+  } catch (error) {
+    return {
+      data: null,
+      inputTokens,
+      outputTokens,
+      error: `Failed to parse Claude response as JSON: ${error instanceof Error ? error.message : "Unknown error"}`,
+    }
+  }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd server && npx vitest run src/lib/shared/claude-json.test.ts`
+Expected: PASS — all 9 tests
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/src/lib/shared/claude-json.ts server/src/lib/shared/claude-json.test.ts
+git commit -m "Add shared callClaudeForJson helper
+
+Handles the full Claude-to-JSON pipeline: API call with assistant
+prefill '{', text extraction, markdown fence stripping, jsonrepair,
+and JSON.parse. Never throws — returns error string on failure.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Update biography synthesis to use shared helper
+
+**Files:**
+- Modify: `server/src/lib/biography-sources/claude-cleanup.ts`
+- Modify: `server/src/lib/biography-sources/claude-cleanup.test.ts`
+
+- [ ] **Step 1: Update claude-cleanup.ts**
+
+In `server/src/lib/biography-sources/claude-cleanup.ts`:
+
+1. Add import at top:
+```typescript
+import { callClaudeForJson } from "../shared/claude-json.js"
+```
+
+2. Remove the now-unused import of `stripMarkdownCodeFences`:
+```typescript
+// REMOVE: import { stripMarkdownCodeFences } from "../claude-batch/response-parser.js"
+```
+
+3. Remove the `new Anthropic()` creation and inline API call. Replace the block from `let response: Anthropic.Message` through the JSON parsing `catch` block (approximately lines 284-370) with:
+
+```typescript
+  const anthropic = new Anthropic()
+
+  // Call Claude via shared helper (handles prefill, fence stripping, jsonrepair)
+  const claudeResult = await newrelic.startSegment("BioClaudeAPI", true, async () => {
+    return callClaudeForJson<Record<string, unknown>>(anthropic, {
+      model,
+      maxTokens: MAX_TOKENS,
+      prompt,
+    })
+  })
+
+  const { inputTokens, outputTokens } = claudeResult
+  const costUsd =
+    (inputTokens * INPUT_COST_PER_MILLION) / 1_000_000 +
+    (outputTokens * OUTPUT_COST_PER_MILLION) / 1_000_000
+
+  // Record Claude API call in New Relic
+  newrelic.recordCustomEvent("BioClaudeAPICall", {
+    actorId: actor.id,
+    actorName: actor.name,
+    model,
+    inputTokens,
+    outputTokens,
+    costUsd,
+    purpose: "biography_synthesis",
+  })
+
+  if (claudeResult.error || !claudeResult.data) {
+    if (claudeResult.error) {
+      newrelic.recordCustomEvent("BioClaudeParseError", {
+        actorId: actor.id,
+        actorName: actor.name,
+        error: claudeResult.error,
+      })
+    }
+    return {
+      data: null,
+      costUsd,
+      model,
+      inputTokens,
+      outputTokens,
+      error: claudeResult.error ?? "No data from Claude",
+    }
+  }
+
+  const parsed = claudeResult.data
+```
+
+After this point, the existing code continues with `parsed` to validate `life_notable_factors`, build the `BiographyData` object, etc. That code stays as-is.
+
+4. Keep the `Anthropic` import (still needed for `new Anthropic()`) but it can now be a type import if the constructor call is the only usage. Actually, keep it as a value import since we call `new Anthropic()`.
+
+- [ ] **Step 2: Update claude-cleanup.test.ts**
+
+The test file mocks `@anthropic-ai/sdk` and provides responses via `mockCreate`. Since we now call `callClaudeForJson` which calls `client.messages.create` internally, and `synthesizeBiography` creates `new Anthropic()` which uses the mocked SDK, the existing mock pattern should still work — the mock SDK creates the mock client, and `callClaudeForJson` calls `create` on it.
+
+However, the response format changes because `callClaudeForJson` handles the prefill internally. The mock responses no longer need to account for the prefill — `callClaudeForJson` prepends `{` itself.
+
+Update the `makeMockApiResponse` function to return full JSON (revert the `slice(1)` that was added for the prefill):
+
+```typescript
+function makeMockApiResponse(
+  jsonData: Record<string, unknown>,
+  tokenOverrides?: { input?: number; output?: number }
+) {
+  // callClaudeForJson prepends "{" from assistant prefill,
+  // so the mock response should be the JSON without the leading brace
+  const fullJson = JSON.stringify(jsonData)
+  return {
+    content: [
+      {
+        type: "text" as const,
+        text: fullJson.slice(1),
+      },
+    ],
+    usage: {
+      input_tokens: tokenOverrides?.input ?? 2000,
+      output_tokens: tokenOverrides?.output ?? 800,
+    },
+  }
+}
+```
+
+Wait — this is actually the same as what's already there after the earlier prefill change. The `makeMockApiResponse` already slices off the leading `{`. So no change needed here.
+
+Update the markdown fence test — it currently strips the brace from the fenced content. Since `callClaudeForJson` handles fences + prepend internally, the mock should provide fenced content without the leading `{`:
+
+The existing test already has this:
+```typescript
+const jsonWithoutBrace = JSON.stringify(validResponse).slice(1)
+mockCreate.mockResolvedValue(
+  makeMockApiResponseRaw("```json\n" + jsonWithoutBrace + "\n```")
+)
+```
+
+This should still work since `callClaudeForJson` strips fences, then prepends `{`.
+
+Run the tests to verify nothing broke.
+
+- [ ] **Step 3: Run tests**
+
+Run: `cd server && npx vitest run src/lib/biography-sources/claude-cleanup.test.ts`
+Expected: PASS — all 48 tests
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add server/src/lib/biography-sources/claude-cleanup.ts server/src/lib/biography-sources/claude-cleanup.test.ts
+git commit -m "Update bio synthesis to use shared callClaudeForJson
+
+Replaces inline Anthropic SDK call, text extraction, fence stripping,
+and JSON parsing with single callClaudeForJson() call. Adds jsonrepair
+as a parsing fallback. Keeps cost computation and New Relic instrumentation.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Update death enrichment synthesis to use shared helper
+
+**Files:**
+- Modify: `server/src/lib/death-sources/claude-cleanup.ts`
+
+- [ ] **Step 1: Update claude-cleanup.ts**
+
+In `server/src/lib/death-sources/claude-cleanup.ts`:
+
+1. Add import at top:
+```typescript
+import { callClaudeForJson } from "../shared/claude-json.js"
+```
+
+2. Remove the now-unused import of `stripMarkdownCodeFences`:
+```typescript
+// REMOVE: import { stripMarkdownCodeFences } from "../claude-batch/response-parser.js"
+```
+
+3. In the `cleanupWithClaude` function, replace the block from `const response = await anthropic.messages.create(...)` through the JSON parsing `catch` block (approximately lines 355-419) with:
+
+```typescript
+  const claudeResult = await callClaudeForJson<ClaudeCleanupResponse>(anthropic, {
+    model: MODEL_ID,
+    maxTokens: MAX_TOKENS,
+    prompt,
+  })
+
+  const inputTokens = claudeResult.inputTokens
+  const outputTokens = claudeResult.outputTokens
+  const costUsd =
+    (inputTokens * INPUT_COST_PER_MILLION) / 1_000_000 +
+    (outputTokens * OUTPUT_COST_PER_MILLION) / 1_000_000
+
+  // Extract text content for logging (reconstruct from parsed data or empty)
+  const responseText = claudeResult.data ? JSON.stringify(claudeResult.data) : ""
+
+  // Log the response
+  logger.logClaudeCleanupResponse(
+    actor.id,
+    actor.name,
+    inputTokens,
+    outputTokens,
+    costUsd,
+    responseText
+  )
+
+  console.log(
+    `  Claude cleanup complete: ${inputTokens} input, ${outputTokens} output tokens ($${costUsd.toFixed(4)})`
+  )
+
+  // Record Claude API call in New Relic
+  newrelic.recordCustomEvent("ClaudeAPICall", {
+    actorId: actor.id,
+    actorName: actor.name,
+    model: MODEL_ID,
+    inputTokens,
+    outputTokens,
+    costUsd,
+    purpose: "death_cleanup",
+  })
+
+  if (claudeResult.error || !claudeResult.data) {
+    const errorMsg = claudeResult.error ?? "No data from Claude"
+    console.error(`JSON parse error for ${actor.name}: ${errorMsg}`)
+    throw new Error(`Failed to parse Claude response: ${errorMsg}`)
+  }
+
+  const parsed = claudeResult.data
+```
+
+Note: The death cleanup throws on errors (unlike bio which returns `{ error }`). Keep this behavior — the caller (`enrichment-runner.ts`) catches and handles the throw.
+
+4. Keep `new Anthropic()` — it's still created earlier in the function (line 338). Keep the `Anthropic` import as a value import.
+
+- [ ] **Step 2: Run death cleanup tests**
+
+Run: `cd server && npx vitest run src/lib/death-sources/claude-cleanup.test.ts`
+Expected: PASS — the death cleanup tests only test `buildCleanupPrompt`, `estimateCleanupCost`, `VALID_NOTABLE_FACTORS`, and `isViolentDeath`. They don't mock the Anthropic SDK or test `cleanupWithClaude` directly, so no mock updates needed.
+
+- [ ] **Step 3: Run type check**
+
+Run: `cd server && npx tsc --noEmit`
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add server/src/lib/death-sources/claude-cleanup.ts
+git commit -m "Update death synthesis to use shared callClaudeForJson
+
+Replaces inline Anthropic SDK call, text extraction, fence stripping,
+and JSON parsing with callClaudeForJson(). Adds assistant prefill and
+jsonrepair — both were missing from death enrichment. Keeps throw-on-error
+behavior for the death enrichment caller.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Full verification
+
+- [ ] **Step 1: Run all tests**
+
+Run: `npm test && cd server && npm test`
+Expected: All tests pass
+
+- [ ] **Step 2: Run type checks**
+
+Run: `npm run type-check && cd server && npx tsc --noEmit`
+Expected: PASS
+
+- [ ] **Step 3: Run lint**
+
+Run: `npm run lint`
+Expected: No new errors
+
+- [ ] **Step 4: Commit any remaining changes**
+
+If lint-staged or formatting produced changes:
+
+```bash
+git add -A && git commit -m "Final formatting fixes
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>"
+```

--- a/docs/superpowers/specs/2026-04-06-shared-claude-json-design.md
+++ b/docs/superpowers/specs/2026-04-06-shared-claude-json-design.md
@@ -1,0 +1,75 @@
+# Shared Claude JSON Helper
+
+Extract a shared helper for calling Claude and parsing JSON responses, used by both biography and death enrichment synthesis.
+
+## Problem
+
+Both `biography-sources/claude-cleanup.ts` and `death-sources/claude-cleanup.ts` independently manage: Anthropic SDK calls, text block extraction, markdown fence stripping, and JSON parsing. Neither uses assistant prefill (causing occasional natural-language responses) or `jsonrepair` (causing failures on minor JSON issues). The bio synthesis just had a production failure (run 74, actor 2454 — Vladimir Lenin) where Claude returned "Looking at..." instead of JSON.
+
+## Solution
+
+New shared helper at `server/src/lib/shared/claude-json.ts` that handles the full call-to-JSON pipeline.
+
+### Function Signature
+
+```typescript
+import type Anthropic from "@anthropic-ai/sdk"
+
+export async function callClaudeForJson<T = Record<string, unknown>>(
+  client: Anthropic,
+  options: {
+    model: string
+    maxTokens: number
+    prompt: string
+    system?: string
+  }
+): Promise<{
+  data: T | null
+  inputTokens: number
+  outputTokens: number
+  error?: string
+}>
+```
+
+### Pipeline
+
+1. `client.messages.create()` with messages `[{ role: "user", content: prompt }, { role: "assistant", content: "{" }]` and optional `system`
+2. Extract first text block from `response.content` — return `{ data: null, error: "No text response" }` if missing
+3. `stripMarkdownCodeFences(text.trim())` — imported from `../claude-batch/response-parser.js`
+4. Prepend `{` (from assistant prefill)
+5. `jsonrepair()` — fixes trailing commas, unescaped quotes, minor malformations
+6. `JSON.parse()` — return `{ data: null, error: "..." }` on failure (never throws)
+7. Return `{ data: T, inputTokens, outputTokens }` on success
+
+### Design Decisions
+
+- **Accepts Anthropic client as parameter** — testable (pass a mock), consistent with pool-threading pattern used elsewhere in the codebase
+- **Returns raw token counts, not cost** — pricing differs by model and changes over time. Callers compute cost from their own constants.
+- **Returns error string, never throws** — callers already handle `{ data: null, error }` pattern. Throwing would require callers to catch and re-wrap.
+- **Generic type parameter `<T>`** — callers can type the parsed result (`callClaudeForJson<BiographyData>(...)`) for downstream validation
+- **`system` is optional** — neither caller uses it today, but it's a natural Claude API parameter
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `server/src/lib/shared/claude-json.ts` | New shared helper |
+| `server/src/lib/shared/claude-json.test.ts` | Tests for all pipeline stages |
+| `server/src/lib/biography-sources/claude-cleanup.ts` | Replace SDK call + parsing with `callClaudeForJson()` |
+| `server/src/lib/biography-sources/claude-cleanup.test.ts` | Update mocks to mock `callClaudeForJson` instead of Anthropic SDK |
+| `server/src/lib/death-sources/claude-cleanup.ts` | Replace SDK call + parsing with `callClaudeForJson()` |
+| `server/src/lib/death-sources/claude-cleanup.test.ts` | Update mocks (if exists) |
+
+## What Stays in Callers
+
+- Cost computation (each has its own cost-per-million constants)
+- New Relic instrumentation (custom events, segments, error tracking)
+- Response validation and post-processing (BiographyData fields, ClaudeCleanupResponse fields)
+- Prompt construction
+- Logging
+
+## Dependencies
+
+- `@anthropic-ai/sdk` — type import for `Anthropic`
+- `stripMarkdownCodeFences` from `../claude-batch/response-parser.js` — already exists
+- `jsonrepair` from `jsonrepair` package — already a project dependency

--- a/docs/superpowers/specs/2026-04-06-shared-claude-json-design.md
+++ b/docs/superpowers/specs/2026-04-06-shared-claude-json-design.md
@@ -56,9 +56,9 @@ export async function callClaudeForJson<T = Record<string, unknown>>(
 | `server/src/lib/shared/claude-json.ts` | New shared helper |
 | `server/src/lib/shared/claude-json.test.ts` | Tests for all pipeline stages |
 | `server/src/lib/biography-sources/claude-cleanup.ts` | Replace SDK call + parsing with `callClaudeForJson()` |
-| `server/src/lib/biography-sources/claude-cleanup.test.ts` | Update mocks to mock `callClaudeForJson` instead of Anthropic SDK |
+| `server/src/lib/biography-sources/claude-cleanup.test.ts` | Keep mocking Anthropic SDK `messages.create()`; update returned text for assistant-prefill JSON behavior |
 | `server/src/lib/death-sources/claude-cleanup.ts` | Replace SDK call + parsing with `callClaudeForJson()` |
-| `server/src/lib/death-sources/claude-cleanup.test.ts` | Update mocks (if exists) |
+| `server/src/lib/death-sources/claude-cleanup.test.ts` | No mock changes needed (tests cover prompt building, not API calls) |
 
 ## What Stays in Callers
 

--- a/server/src/lib/biography-sources/claude-cleanup.test.ts
+++ b/server/src/lib/biography-sources/claude-cleanup.test.ts
@@ -112,11 +112,15 @@ function makeMockApiResponse(
   jsonData: Record<string, unknown>,
   tokenOverrides?: { input?: number; output?: number }
 ) {
+  // Strip leading "{" to match assistant prefill behavior —
+  // the API call uses { role: "assistant", content: "{" } so Claude's
+  // response continues from after the opening brace
+  const fullJson = JSON.stringify(jsonData)
   return {
     content: [
       {
         type: "text" as const,
-        text: JSON.stringify(jsonData),
+        text: fullJson.slice(1),
       },
     ],
     usage: {
@@ -451,9 +455,9 @@ describe("claude-cleanup (biography)", () => {
 
     it("strips markdown fences from response", async () => {
       const validResponse = makeValidClaudeResponse()
-      mockCreate.mockResolvedValue(
-        makeMockApiResponseRaw("```json\n" + JSON.stringify(validResponse) + "\n```")
-      )
+      // With assistant prefill "{", Claude's fenced response omits the leading brace
+      const jsonWithoutBrace = JSON.stringify(validResponse).slice(1)
+      mockCreate.mockResolvedValue(makeMockApiResponseRaw("```json\n" + jsonWithoutBrace + "\n```"))
 
       const result = await synthesizeBiography(mockActor, mockSources)
 

--- a/server/src/lib/biography-sources/claude-cleanup.ts
+++ b/server/src/lib/biography-sources/claude-cleanup.ts
@@ -314,6 +314,11 @@ export async function synthesizeBiography(
       actorName: actor.name,
       error: errorMsg,
     })
+    newrelic.noticeError(new Error(errorMsg), {
+      actorId: actor.id,
+      actorName: actor.name,
+      purpose: "biography_synthesis",
+    })
     return {
       data: null,
       costUsd,

--- a/server/src/lib/biography-sources/claude-cleanup.ts
+++ b/server/src/lib/biography-sources/claude-cleanup.ts
@@ -11,7 +11,7 @@ import newrelic from "newrelic"
 import Anthropic from "@anthropic-ai/sdk"
 import type { ActorForBiography, RawBiographySourceData, BiographyData } from "./types.js"
 import { BiographySourceType, VALID_LIFE_NOTABLE_FACTORS } from "./types.js"
-import { stripMarkdownCodeFences } from "../claude-batch/response-parser.js"
+import { callClaudeForJson } from "../shared/claude-json.js"
 import { sanitizeSourceText } from "../shared/sanitize-source-text.js"
 import { getPool } from "../db/pool.js"
 import { saveRejectedFactors } from "../rejected-factors.js"
@@ -281,44 +281,17 @@ export async function synthesizeBiography(
 
   const prompt = buildBiographySynthesisPrompt(actor, sorted)
 
-  let response: Anthropic.Message
-  try {
-    const anthropic = new Anthropic()
-    // Wrap Claude API call in New Relic segment
-    response = await newrelic.startSegment("BioClaudeAPI", true, async () => {
-      return anthropic.messages.create({
-        model,
-        max_tokens: MAX_TOKENS,
-        messages: [
-          { role: "user", content: prompt },
-          { role: "assistant", content: "{" },
-        ],
-      })
-    })
-  } catch (error) {
-    const errorMsg = error instanceof Error ? error.message : "Unknown error"
-    newrelic.recordCustomEvent("BioClaudeAPIError", {
-      actorId: actor.id,
-      actorName: actor.name,
+  // Call Claude via shared helper (handles prefill, fence stripping, jsonrepair)
+  const anthropic = new Anthropic()
+  const claudeResult = await newrelic.startSegment("BioClaudeAPI", true, async () => {
+    return callClaudeForJson<Record<string, unknown>>(anthropic, {
       model,
-      error: errorMsg,
+      maxTokens: MAX_TOKENS,
+      prompt,
     })
-    if (error instanceof Error) {
-      newrelic.noticeError(error, { actorId: actor.id, actorName: actor.name })
-    }
-    return {
-      data: null,
-      costUsd: 0,
-      model,
-      inputTokens: 0,
-      outputTokens: 0,
-      error: `Claude API error: ${errorMsg}`,
-    }
-  }
+  })
 
-  // Calculate cost
-  const inputTokens = response.usage.input_tokens
-  const outputTokens = response.usage.output_tokens
+  const { inputTokens, outputTokens } = claudeResult
   const costUsd =
     (inputTokens * INPUT_COST_PER_MILLION) / 1_000_000 +
     (outputTokens * OUTPUT_COST_PER_MILLION) / 1_000_000
@@ -334,44 +307,24 @@ export async function synthesizeBiography(
     purpose: "biography_synthesis",
   })
 
-  // Extract text content
-  const textBlock = response.content.find((block) => block.type === "text")
-  if (!textBlock || textBlock.type !== "text") {
-    return {
-      data: null,
-      costUsd,
-      model,
-      inputTokens,
-      outputTokens,
-      error: "No text response from Claude",
-    }
-  }
-
-  // Parse JSON response — strip fences first, then prepend "{" from assistant prefill
-  let parsed: Record<string, unknown>
-  try {
-    const stripped = stripMarkdownCodeFences(textBlock.text.trim())
-    const jsonText = "{" + stripped
-    parsed = JSON.parse(jsonText) as Record<string, unknown>
-  } catch (error) {
-    const parseErrorMsg = error instanceof Error ? error.message : "Unknown error"
+  if (claudeResult.error || !claudeResult.data) {
+    const errorMsg = claudeResult.error ?? "No data from Claude"
     newrelic.recordCustomEvent("BioClaudeParseError", {
       actorId: actor.id,
       actorName: actor.name,
-      error: parseErrorMsg,
+      error: errorMsg,
     })
-    if (error instanceof Error) {
-      newrelic.noticeError(error, { actorId: actor.id, actorName: actor.name })
-    }
     return {
       data: null,
       costUsd,
       model,
       inputTokens,
       outputTokens,
-      error: `Failed to parse Claude response as JSON: ${parseErrorMsg}`,
+      error: errorMsg,
     }
   }
+
+  const parsed = claudeResult.data
 
   // Validate life_notable_factors against VALID set
   const allFactors = (

--- a/server/src/lib/biography-sources/claude-cleanup.ts
+++ b/server/src/lib/biography-sources/claude-cleanup.ts
@@ -289,7 +289,10 @@ export async function synthesizeBiography(
       return anthropic.messages.create({
         model,
         max_tokens: MAX_TOKENS,
-        messages: [{ role: "user", content: prompt }],
+        messages: [
+          { role: "user", content: prompt },
+          { role: "assistant", content: "{" },
+        ],
       })
     })
   } catch (error) {
@@ -344,10 +347,11 @@ export async function synthesizeBiography(
     }
   }
 
-  // Parse JSON response
+  // Parse JSON response — strip fences first, then prepend "{" from assistant prefill
   let parsed: Record<string, unknown>
   try {
-    const jsonText = stripMarkdownCodeFences(textBlock.text.trim())
+    const stripped = stripMarkdownCodeFences(textBlock.text.trim())
+    const jsonText = "{" + stripped
     parsed = JSON.parse(jsonText) as Record<string, unknown>
   } catch (error) {
     const parseErrorMsg = error instanceof Error ? error.message : "Unknown error"

--- a/server/src/lib/biography-sources/integration.test.ts
+++ b/server/src/lib/biography-sources/integration.test.ts
@@ -187,37 +187,41 @@ const WIKIPEDIA_PERSONAL_LIFE_HTML = {
 /**
  * Claude synthesis response with realistic biography JSON.
  */
+// callClaudeForJson prepends "{" from assistant prefill,
+// so the mock response should be the JSON without the leading brace
+const CLAUDE_SYNTHESIS_JSON = {
+  narrative:
+    "The boy who would become John Wayne grew up far from Hollywood glamour. Born Marion Robert Morrison in a small Iowa farmhouse, he spent his earliest years watching his father struggle as a pharmacist in various small towns. When the family relocated to Southern California, young Marion found himself an outsider, a Midwestern kid in a sun-bleached California world. He threw himself into football at Glendale Union High School, where he also served as president of the Latin Society. A football scholarship took him to the University of Southern California, but a body-surfing injury ended his athletic career and, with it, his scholarship. Stranded without tuition money, he took odd jobs at the Fox Film lot — a decision that would reshape American cinema. Wayne married three times. His first marriage to Josephine Saenz produced four children but ended in 1945. His union with Esperanza Baur was turbulent, marked by jealousy and public arguments. His third marriage, to Peruvian actress Pilar Pallete, lasted until his death. He struggled with alcoholism during the 1950s. In 1964, doctors removed his entire left lung after discovering cancer — Wayne later became an advocate for cancer awareness.",
+  narrative_confidence: "high",
+  life_notable_factors: ["athlete", "rags_to_riches", "addiction_recovery"],
+  birthplace_details:
+    "Born in Winterset, Iowa, a small rural town. His family moved to Palmdale and then Glendale, California, during his childhood.",
+  family_background:
+    "Son of Clyde Leonard Morrison, a pharmacist, and Mary Alberta Brown. Had one younger brother, Robert Emmet Morrison.",
+  education:
+    "Attended Glendale Union High School, where he was president of the Latin Society and played football. Received a football scholarship to the University of Southern California but lost it after a body-surfing injury.",
+  pre_fame_life:
+    "After losing his scholarship, took odd jobs at the Fox Film lot to support himself.",
+  fame_catalyst:
+    "His work as a prop man at Fox Film studios led director John Ford to take notice, beginning a decades-long professional relationship.",
+  personal_struggles:
+    "Struggled with alcoholism in the 1950s. Diagnosed with lung cancer in 1964 and had his left lung removed.",
+  relationships:
+    "Married three times: Josephine Saenz (1933-1945), Esperanza Baur (1946-1954), Pilar Pallete (1954-1979). Seven children total.",
+  lesser_known_facts: [
+    "Was president of the Latin Society in high school",
+    "Lost his football scholarship due to a body-surfing injury",
+    "His birth name was Marion Robert Morrison",
+    "His father was a pharmacist who struggled financially",
+  ],
+  has_substantive_content: true,
+}
+
 const CLAUDE_SYNTHESIS_RESPONSE = {
   content: [
     {
       type: "text" as const,
-      text: JSON.stringify({
-        narrative:
-          "The boy who would become John Wayne grew up far from Hollywood glamour. Born Marion Robert Morrison in a small Iowa farmhouse, he spent his earliest years watching his father struggle as a pharmacist in various small towns. When the family relocated to Southern California, young Marion found himself an outsider, a Midwestern kid in a sun-bleached California world. He threw himself into football at Glendale Union High School, where he also served as president of the Latin Society. A football scholarship took him to the University of Southern California, but a body-surfing injury ended his athletic career and, with it, his scholarship. Stranded without tuition money, he took odd jobs at the Fox Film lot — a decision that would reshape American cinema. Wayne married three times. His first marriage to Josephine Saenz produced four children but ended in 1945. His union with Esperanza Baur was turbulent, marked by jealousy and public arguments. His third marriage, to Peruvian actress Pilar Pallete, lasted until his death. He struggled with alcoholism during the 1950s. In 1964, doctors removed his entire left lung after discovering cancer — Wayne later became an advocate for cancer awareness.",
-        narrative_confidence: "high",
-        life_notable_factors: ["athlete", "rags_to_riches", "addiction_recovery"],
-        birthplace_details:
-          "Born in Winterset, Iowa, a small rural town. His family moved to Palmdale and then Glendale, California, during his childhood.",
-        family_background:
-          "Son of Clyde Leonard Morrison, a pharmacist, and Mary Alberta Brown. Had one younger brother, Robert Emmet Morrison.",
-        education:
-          "Attended Glendale Union High School, where he was president of the Latin Society and played football. Received a football scholarship to the University of Southern California but lost it after a body-surfing injury.",
-        pre_fame_life:
-          "After losing his scholarship, took odd jobs at the Fox Film lot to support himself.",
-        fame_catalyst:
-          "His work as a prop man at Fox Film studios led director John Ford to take notice, beginning a decades-long professional relationship.",
-        personal_struggles:
-          "Struggled with alcoholism in the 1950s. Diagnosed with lung cancer in 1964 and had his left lung removed.",
-        relationships:
-          "Married three times: Josephine Saenz (1933-1945), Esperanza Baur (1946-1954), Pilar Pallete (1954-1979). Seven children total.",
-        lesser_known_facts: [
-          "Was president of the Latin Society in high school",
-          "Lost his football scholarship due to a body-surfing injury",
-          "His birth name was Marion Robert Morrison",
-          "His father was a pharmacist who struggled financially",
-        ],
-        has_substantive_content: true,
-      }),
+      text: JSON.stringify(CLAUDE_SYNTHESIS_JSON).slice(1),
     },
   ],
   usage: {
@@ -499,8 +503,9 @@ describe("Biography Enrichment Integration Test", () => {
       const synthesisCallArgs = anthropicMockCreate.mock.calls[0][0]
       expect(synthesisCallArgs.model).toBe("claude-sonnet-4-20250514")
       expect(synthesisCallArgs.max_tokens).toBe(4096)
-      expect(synthesisCallArgs.messages).toHaveLength(1)
+      expect(synthesisCallArgs.messages).toHaveLength(2)
       expect(synthesisCallArgs.messages[0].role).toBe("user")
+      expect(synthesisCallArgs.messages[1]).toEqual({ role: "assistant", content: "{" })
       // Prompt should contain actor name and source material
       expect(synthesisCallArgs.messages[0].content).toContain("John Wayne")
 
@@ -621,26 +626,22 @@ describe("Biography Enrichment Integration Test", () => {
 
     it("filters invalid life_notable_factors from Claude response", async () => {
       // Return response with a mix of valid and invalid factors
+      const factorsJson = JSON.stringify({
+        narrative: "Full narrative about John Wayne's life.",
+        narrative_confidence: "medium",
+        life_notable_factors: ["military_service", "invented_factor", "athlete", "fake_tag"],
+        birthplace_details: null,
+        family_background: null,
+        education: null,
+        pre_fame_life: null,
+        fame_catalyst: null,
+        personal_struggles: null,
+        relationships: null,
+        lesser_known_facts: [],
+        has_substantive_content: true,
+      })
       anthropicMockCreate.mockResolvedValue({
-        content: [
-          {
-            type: "text" as const,
-            text: JSON.stringify({
-              narrative: "Full narrative about John Wayne's life.",
-              narrative_confidence: "medium",
-              life_notable_factors: ["military_service", "invented_factor", "athlete", "fake_tag"],
-              birthplace_details: null,
-              family_background: null,
-              education: null,
-              pre_fame_life: null,
-              fame_catalyst: null,
-              personal_struggles: null,
-              relationships: null,
-              lesser_known_facts: [],
-              has_substantive_content: true,
-            }),
-          },
-        ],
+        content: [{ type: "text" as const, text: factorsJson.slice(1) }],
         usage: { input_tokens: 1000, output_tokens: 400 },
       })
 

--- a/server/src/lib/death-sources/claude-cleanup.ts
+++ b/server/src/lib/death-sources/claude-cleanup.ts
@@ -13,8 +13,8 @@
  */
 
 import Anthropic from "@anthropic-ai/sdk"
-import { stripMarkdownCodeFences } from "../claude-batch/response-parser.js"
 import { DeathMannerSchema } from "../claude-batch/schemas.js"
+import { callClaudeForJson } from "../shared/claude-json.js"
 import type {
   ActorForEnrichment,
   CleanedDeathInfo,
@@ -352,29 +352,20 @@ export async function cleanupWithClaude(
   // Log the request
   logger.logClaudeCleanupRequest(actor.id, actor.name, rawSources.length, prompt)
 
-  const response = await anthropic.messages.create({
+  // Call Claude via shared helper (handles prefill, fence stripping, jsonrepair)
+  const claudeResult = await callClaudeForJson<ClaudeCleanupResponse>(anthropic, {
     model: MODEL_ID,
-    max_tokens: MAX_TOKENS,
-    messages: [
-      {
-        role: "user",
-        content: prompt,
-      },
-    ],
+    maxTokens: MAX_TOKENS,
+    prompt,
   })
 
-  // Calculate cost
-  const inputTokens = response.usage.input_tokens
-  const outputTokens = response.usage.output_tokens
+  const { inputTokens, outputTokens } = claudeResult
   const costUsd =
     (inputTokens * INPUT_COST_PER_MILLION) / 1_000_000 +
     (outputTokens * OUTPUT_COST_PER_MILLION) / 1_000_000
 
-  // Extract text content for logging
-  const textBlock = response.content.find((block) => block.type === "text")
-  const responseText = textBlock?.type === "text" ? textBlock.text : ""
-
   // Log the response
+  const responseText = claudeResult.data ? JSON.stringify(claudeResult.data) : ""
   logger.logClaudeCleanupResponse(
     actor.id,
     actor.name,
@@ -393,30 +384,19 @@ export async function cleanupWithClaude(
     actorId: actor.id,
     actorName: actor.name,
     model: MODEL_ID,
-    inputTokens: inputTokens,
-    outputTokens: outputTokens,
-    costUsd: costUsd,
+    inputTokens,
+    outputTokens,
+    costUsd,
     purpose: "death_cleanup",
   })
 
-  // Verify we have text content
-  if (!textBlock || textBlock.type !== "text") {
-    throw new Error("No text response from Claude")
+  if (claudeResult.error || !claudeResult.data) {
+    const errorMsg = claudeResult.error ?? "No data from Claude"
+    console.error(`Claude parse error for ${actor.name}: ${errorMsg}`)
+    throw new Error(`Failed to parse Claude response: ${errorMsg}`)
   }
 
-  // Parse JSON response
-  const jsonText = stripMarkdownCodeFences(textBlock.text)
-  let parsed: ClaudeCleanupResponse
-
-  try {
-    parsed = JSON.parse(jsonText) as ClaudeCleanupResponse
-  } catch (error) {
-    console.error(`JSON parse error for ${actor.name}:`, error)
-    console.error("Raw response:", textBlock.text.substring(0, 500))
-    throw new Error(
-      `Failed to parse Claude response: ${error instanceof Error ? error.message : "Unknown error"}`
-    )
-  }
+  const parsed = claudeResult.data
 
   // Convert related_celebrities to proper format
   const relatedCelebrities: RelatedCelebrity[] | null = Array.isArray(parsed.related_celebrities)

--- a/server/src/lib/death-sources/claude-cleanup.ts
+++ b/server/src/lib/death-sources/claude-cleanup.ts
@@ -392,7 +392,9 @@ export async function cleanupWithClaude(
 
   if (claudeResult.error || !claudeResult.data) {
     const errorMsg = claudeResult.error ?? "No data from Claude"
-    console.error(`Claude parse error for ${actor.name}: ${errorMsg}`)
+    console.error(`Claude parse error for ${actor.name}: ${errorMsg}`, {
+      rawSnippet: claudeResult.rawSnippet ?? null,
+    })
     throw new Error(`Failed to parse Claude response: ${errorMsg}`)
   }
 

--- a/server/src/lib/shared/claude-json.test.ts
+++ b/server/src/lib/shared/claude-json.test.ts
@@ -102,14 +102,23 @@ describe("callClaudeForJson", () => {
     expect(result.outputTokens).toBe(0)
   })
 
-  it("returns error when response is completely unparseable", async () => {
+  it("returns error with rawSnippet when response is completely unparseable", async () => {
     const client = mockClient("Looking at the sources, I can see that...")
     const result = await callClaudeForJson(client, opts)
 
     expect(result.data).toBeNull()
     expect(result.error).toContain("Failed to parse")
+    expect(result.rawSnippet).toBe("Looking at the sources, I can see that...")
     expect(result.inputTokens).toBe(100)
     expect(result.outputTokens).toBe(50)
+  })
+
+  it("handles response that already starts with { (Claude ignores prefill)", async () => {
+    const client = mockClient('{"name": "John", "age": 30}')
+    const result = await callClaudeForJson(client, opts)
+
+    expect(result.data).toEqual({ name: "John", age: 30 })
+    expect(result.error).toBeUndefined()
   })
 
   it("returns error when API call fails", async () => {

--- a/server/src/lib/shared/claude-json.test.ts
+++ b/server/src/lib/shared/claude-json.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, vi } from "vitest"
+import { callClaudeForJson } from "./claude-json.js"
+
+function mockClient(textResponse: string, tokens?: { input?: number; output?: number }) {
+  return {
+    messages: {
+      create: vi.fn().mockResolvedValue({
+        content: [{ type: "text", text: textResponse }],
+        usage: {
+          input_tokens: tokens?.input ?? 100,
+          output_tokens: tokens?.output ?? 50,
+        },
+      }),
+    },
+  } as any
+}
+
+function mockClientNoText() {
+  return {
+    messages: {
+      create: vi.fn().mockResolvedValue({
+        content: [{ type: "image", source: {} }],
+        usage: { input_tokens: 100, output_tokens: 0 },
+      }),
+    },
+  } as any
+}
+
+function mockClientError(error: Error) {
+  return {
+    messages: {
+      create: vi.fn().mockRejectedValue(error),
+    },
+  } as any
+}
+
+describe("callClaudeForJson", () => {
+  const opts = { model: "claude-sonnet-4-20250514", maxTokens: 1024, prompt: "Return JSON" }
+
+  it("parses valid JSON response (prefill prepends opening brace)", async () => {
+    const client = mockClient('"name": "John", "age": 30}')
+    const result = await callClaudeForJson(client, opts)
+
+    expect(result.data).toEqual({ name: "John", age: 30 })
+    expect(result.error).toBeUndefined()
+    expect(result.inputTokens).toBe(100)
+    expect(result.outputTokens).toBe(50)
+  })
+
+  it("sends assistant prefill in messages", async () => {
+    const client = mockClient('"ok": true}')
+    await callClaudeForJson(client, opts)
+
+    const call = client.messages.create.mock.calls[0][0]
+    expect(call.messages).toEqual([
+      { role: "user", content: "Return JSON" },
+      { role: "assistant", content: "{" },
+    ])
+    expect(call.model).toBe("claude-sonnet-4-20250514")
+    expect(call.max_tokens).toBe(1024)
+  })
+
+  it("passes system parameter when provided", async () => {
+    const client = mockClient('"ok": true}')
+    await callClaudeForJson(client, { ...opts, system: "You are a JSON bot" })
+
+    const call = client.messages.create.mock.calls[0][0]
+    expect(call.system).toBe("You are a JSON bot")
+  })
+
+  it("omits system parameter when not provided", async () => {
+    const client = mockClient('"ok": true}')
+    await callClaudeForJson(client, opts)
+
+    const call = client.messages.create.mock.calls[0][0]
+    expect(call.system).toBeUndefined()
+  })
+
+  it("strips markdown code fences before parsing", async () => {
+    const client = mockClient('```json\n"narrative": "test"}\n```')
+    const result = await callClaudeForJson(client, opts)
+
+    expect(result.data).toEqual({ narrative: "test" })
+    expect(result.error).toBeUndefined()
+  })
+
+  it("repairs minor JSON issues via jsonrepair", async () => {
+    const client = mockClient('"name": "John", "age": 30,}')
+    const result = await callClaudeForJson(client, opts)
+
+    expect(result.data).toEqual({ name: "John", age: 30 })
+    expect(result.error).toBeUndefined()
+  })
+
+  it("returns error when no text block in response", async () => {
+    const client = mockClientNoText()
+    const result = await callClaudeForJson(client, opts)
+
+    expect(result.data).toBeNull()
+    expect(result.error).toBe("No text response from Claude")
+    expect(result.inputTokens).toBe(100)
+    expect(result.outputTokens).toBe(0)
+  })
+
+  it("returns error when response is completely unparseable", async () => {
+    const client = mockClient("Looking at the sources, I can see that...")
+    const result = await callClaudeForJson(client, opts)
+
+    expect(result.data).toBeNull()
+    expect(result.error).toContain("Failed to parse")
+    expect(result.inputTokens).toBe(100)
+    expect(result.outputTokens).toBe(50)
+  })
+
+  it("returns error when API call fails", async () => {
+    const client = mockClientError(new Error("Rate limit exceeded"))
+    const result = await callClaudeForJson(client, opts)
+
+    expect(result.data).toBeNull()
+    expect(result.error).toBe("Claude API error: Rate limit exceeded")
+    expect(result.inputTokens).toBe(0)
+    expect(result.outputTokens).toBe(0)
+  })
+
+  it("returns token counts from response usage", async () => {
+    const client = mockClient('"ok": true}', { input: 3000, output: 1200 })
+    const result = await callClaudeForJson(client, opts)
+
+    expect(result.inputTokens).toBe(3000)
+    expect(result.outputTokens).toBe(1200)
+  })
+})

--- a/server/src/lib/shared/claude-json.ts
+++ b/server/src/lib/shared/claude-json.ts
@@ -17,6 +17,8 @@ export interface ClaudeJsonResult<T> {
   inputTokens: number
   outputTokens: number
   error?: string
+  /** Truncated raw text from Claude on parse failure, for debugging. */
+  rawSnippet?: string
 }
 
 export async function callClaudeForJson<T = Record<string, unknown>>(
@@ -51,11 +53,12 @@ export async function callClaudeForJson<T = Record<string, unknown>>(
     }
   }
 
-  const inputTokens = response.usage.input_tokens
-  const outputTokens = response.usage.output_tokens
+  // Defensive access — honor the "never throws" contract
+  const inputTokens = response.usage?.input_tokens ?? 0
+  const outputTokens = response.usage?.output_tokens ?? 0
 
   // Extract text block
-  const textBlock = response.content.find((block) => block.type === "text")
+  const textBlock = response.content?.find((block) => block.type === "text")
   if (!textBlock || textBlock.type !== "text") {
     return {
       data: null,
@@ -65,10 +68,10 @@ export async function callClaudeForJson<T = Record<string, unknown>>(
     }
   }
 
-  // Parse JSON: strip fences, prepend { from prefill, repair, parse
+  // Parse JSON: strip fences, restore { from prefill when needed, repair, parse
   try {
     const stripped = stripMarkdownCodeFences(textBlock.text.trim())
-    const withBrace = "{" + stripped
+    const withBrace = stripped.startsWith("{") ? stripped : "{" + stripped
     const repaired = jsonrepair(withBrace)
     const parsed = JSON.parse(repaired) as T
     return { data: parsed, inputTokens, outputTokens }
@@ -78,6 +81,7 @@ export async function callClaudeForJson<T = Record<string, unknown>>(
       inputTokens,
       outputTokens,
       error: `Failed to parse Claude response as JSON: ${error instanceof Error ? error.message : "Unknown error"}`,
+      rawSnippet: textBlock.text.slice(0, 200),
     }
   }
 }

--- a/server/src/lib/shared/claude-json.ts
+++ b/server/src/lib/shared/claude-json.ts
@@ -1,0 +1,83 @@
+/**
+ * Shared helper for calling Claude and parsing JSON responses.
+ *
+ * Handles the full pipeline: API call with assistant prefill, text extraction,
+ * markdown fence stripping, jsonrepair, and JSON.parse. Used by both biography
+ * and death enrichment synthesis.
+ *
+ * Never throws — returns { data: null, error } on failure.
+ */
+
+import type Anthropic from "@anthropic-ai/sdk"
+import { stripMarkdownCodeFences } from "../claude-batch/response-parser.js"
+import { jsonrepair } from "jsonrepair"
+
+export interface ClaudeJsonResult<T> {
+  data: T | null
+  inputTokens: number
+  outputTokens: number
+  error?: string
+}
+
+export async function callClaudeForJson<T = Record<string, unknown>>(
+  client: Anthropic,
+  options: {
+    model: string
+    maxTokens: number
+    prompt: string
+    system?: string
+  }
+): Promise<ClaudeJsonResult<T>> {
+  const { model, maxTokens, prompt, system } = options
+
+  // Call Claude with assistant prefill to force JSON output
+  let response: Anthropic.Message
+  try {
+    response = await client.messages.create({
+      model,
+      max_tokens: maxTokens,
+      messages: [
+        { role: "user", content: prompt },
+        { role: "assistant", content: "{" },
+      ],
+      ...(system !== undefined && { system }),
+    })
+  } catch (error) {
+    return {
+      data: null,
+      inputTokens: 0,
+      outputTokens: 0,
+      error: `Claude API error: ${error instanceof Error ? error.message : "Unknown error"}`,
+    }
+  }
+
+  const inputTokens = response.usage.input_tokens
+  const outputTokens = response.usage.output_tokens
+
+  // Extract text block
+  const textBlock = response.content.find((block) => block.type === "text")
+  if (!textBlock || textBlock.type !== "text") {
+    return {
+      data: null,
+      inputTokens,
+      outputTokens,
+      error: "No text response from Claude",
+    }
+  }
+
+  // Parse JSON: strip fences, prepend { from prefill, repair, parse
+  try {
+    const stripped = stripMarkdownCodeFences(textBlock.text.trim())
+    const withBrace = "{" + stripped
+    const repaired = jsonrepair(withBrace)
+    const parsed = JSON.parse(repaired) as T
+    return { data: parsed, inputTokens, outputTokens }
+  } catch (error) {
+    return {
+      data: null,
+      inputTokens,
+      outputTokens,
+      error: `Failed to parse Claude response as JSON: ${error instanceof Error ? error.message : "Unknown error"}`,
+    }
+  }
+}

--- a/server/src/lib/shared/claude-json.ts
+++ b/server/src/lib/shared/claude-json.ts
@@ -57,8 +57,9 @@ export async function callClaudeForJson<T = Record<string, unknown>>(
   const inputTokens = response.usage?.input_tokens ?? 0
   const outputTokens = response.usage?.output_tokens ?? 0
 
-  // Extract text block
-  const textBlock = response.content?.find((block) => block.type === "text")
+  // Extract text block — Array.isArray guard for never-throws contract
+  const contentBlocks = Array.isArray(response.content) ? response.content : []
+  const textBlock = contentBlocks.find((block) => block.type === "text")
   if (!textBlock || textBlock.type !== "text") {
     return {
       data: null,


### PR DESCRIPTION
## Summary

- Both bio and death enrichment synthesis independently managed Anthropic SDK calls, text extraction, fence stripping, and JSON parsing
- Neither used assistant prefill (causing occasional natural-language responses) or `jsonrepair` (failing on minor JSON malformations)
- Production failure: bio run 74, actor 2454 (Vladimir Lenin) — Claude returned "Looking at..." instead of JSON

## Changes

- New `callClaudeForJson()` in `server/src/lib/shared/claude-json.ts`:
  - Assistant prefill `{` forces JSON output
  - `stripMarkdownCodeFences` for fenced responses
  - `jsonrepair` fixes trailing commas, unescaped quotes
  - Never throws — returns `{ data: null, error }` on failure
  - Accepts Anthropic client as parameter (testable)
  - Returns raw token counts (callers compute cost)
- Bio synthesis (`claude-cleanup.ts`): 62 lines removed, 15 added — replaced with single `callClaudeForJson()` call
- Death synthesis (`claude-cleanup.ts`): 82 lines removed, 63 added — replaced SDK call + parsing, gains prefill + jsonrepair it never had

## Test Plan

- [x] 10 new tests for `callClaudeForJson` (prefill, fences, jsonrepair, errors, token counts)
- [x] All 48 bio claude-cleanup tests pass
- [x] All 34 death claude-cleanup tests pass
- [x] All 8 bio integration tests pass (mocks updated for prefill behavior)
- [x] Full suite: 176 frontend + 300 server test files pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)