### PR TITLE
Fix NR uninstrumented database by aligning APM hostname with infra agent

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -105,6 +105,8 @@ services:
       - DATABASE_URL=postgresql://${POSTGRES_USER:-deadonfilm}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB:-deadonfilm}
       - REDIS_URL=redis://redis:6379
       - REDIS_JOBS_URL=redis://redis-jobs:6379
+      # Must match NRIA_DISPLAY_NAME so NR links APM datastore spans to infra integrations
+      - NEW_RELIC_PROCESS_HOST_DISPLAY_NAME=deadonfilm-server
     depends_on:
       db:
         condition: service_healthy
@@ -206,6 +208,8 @@ services:
       - DATABASE_URL=postgresql://${POSTGRES_USER:-deadonfilm}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB:-deadonfilm}
       - REDIS_URL=redis://redis:6379
       - REDIS_JOBS_URL=redis://redis-jobs:6379
+      # Must match NRIA_DISPLAY_NAME so NR links APM datastore spans to infra integrations
+      - NEW_RELIC_PROCESS_HOST_DISPLAY_NAME=deadonfilm-server
       # PATH needed so supercronic can find itself when forking for process reaping
       - PATH=/usr/local/bin:/usr/bin:/bin
     healthcheck:
@@ -274,6 +278,8 @@ services:
       - DATABASE_URL=postgresql://${POSTGRES_USER:-deadonfilm}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB:-deadonfilm}
       - REDIS_URL=redis://redis:6379
       - REDIS_JOBS_URL=redis://redis-jobs:6379
+      # Must match NRIA_DISPLAY_NAME so NR links APM datastore spans to infra integrations
+      - NEW_RELIC_PROCESS_HOST_DISPLAY_NAME=deadonfilm-server
       # Optional: limit which queues this worker processes
       # - WORKER_QUEUES=enrichment,ratings
     depends_on:

--- a/newrelic-postgres-config.yml
+++ b/newrelic-postgres-config.yml
@@ -21,6 +21,7 @@ integrations:
     labels:
       env: production
       role: database
+      endpoint: db
     inventory_source: config/postgresql
 
 # PostgreSQL log forwarding to New Relic Logs

--- a/newrelic-redis-config.yml
+++ b/newrelic-redis-config.yml
@@ -14,4 +14,5 @@ integrations:
     labels:
       env: production
       role: cache
+      endpoint: redis
     inventory_source: config/redis

--- a/server/newrelic.cjs
+++ b/server/newrelic.cjs
@@ -119,6 +119,15 @@ exports.config = {
     ]
   },
 
+  // Report a stable hostname instead of Docker container ID.
+  // Must match NRIA_DISPLAY_NAME in docker-compose.yml so NR can link
+  // APM datastore spans to the infrastructure PostgreSQL/Redis integrations.
+  // Without this, NR shows databases as "uninstrumented" because the APM
+  // agent reports host=<container-id> while infra reports host=deadonfilm-server.
+  process_host: {
+    display_name: process.env.NEW_RELIC_PROCESS_HOST_DISPLAY_NAME || undefined
+  },
+
   // Code-level metrics (shows function-level performance)
   code_level_metrics: {
     enabled: true


### PR DESCRIPTION
## Summary

NR APM Databases page showed PostgreSQL as uninstrumented and the service map showed dotted hexagons for databases. The root cause: the APM Node.js agent reported its hostname as Docker container IDs (53ee815af6fe) while the infrastructure agent reported as deadonfilm-server. NR could not link the APM datastore spans to the nri-postgresql integration entity.

## Changes

- server/newrelic.cjs: Add process_host.display_name config, read from NEW_RELIC_PROCESS_HOST_DISPLAY_NAME env var
- docker-compose.yml: Set NEW_RELIC_PROCESS_HOST_DISPLAY_NAME=deadonfilm-server on app, cron, and worker services to match NRIA_DISPLAY_NAME

## How It Works

NR links APM datastore spans to infrastructure integration entities by matching hostnames. In Docker, each container gets a random hex ID as its hostname. By setting process_host.display_name to the same value as the infra agent NRIA_DISPLAY_NAME, NR recognizes them as the same logical host and links the entities.

## Test Plan

- [x] All 37 tests pass (stats + page-views)
- [ ] After deploy, verify NR APM Databases page no longer shows uninstrumented
- [ ] Verify NR service map shows solid hexagon for database instead of dotted