### PR TITLE
Fix retired Claude model IDs and current-gen API incompatibilities

### DIFF
--- a/.claude/rules/biography-enrichment.md
+++ b/.claude/rules/biography-enrichment.md
@@ -157,7 +157,7 @@ DuckDuckGo is limited to 2-3 concurrent requests across all sources to prevent C
   confidenceThreshold: 0.6,      // Content confidence threshold for high-quality counting
   reliabilityThreshold: 0.6,     // Source reliability threshold
   useReliabilityThreshold: true, // Enforce reliability threshold
-  synthesisModel: "claude-sonnet-4-20250514",
+  synthesisModel: CLAUDE_MODELS.sonnet.id,  // see server/src/lib/claude-models.ts
   sourceCategories: {
     free: true,                  // Wikidata, Wikipedia
     reference: true,             // Britannica, Biography.com, TCM, AllMusic

--- a/.claude/rules/coding-standards.md
+++ b/.claude/rules/coding-standards.md
@@ -63,6 +63,41 @@ Every interactive element must be accessible:
 </Link>
 ```
 
+## AI Model IDs
+
+**Never hardcode an Anthropic model ID.** Import it from the registry at
+`server/src/lib/claude-models.ts`:
+
+```typescript
+// BAD — a private copy that goes stale silently when the model retires
+const MODEL = "claude-sonnet-4-20250514"
+const INPUT_COST_PER_MILLION = 3
+
+// GOOD — single source of truth, ID and pricing stay in sync
+import { CLAUDE_MODELS } from "../claude-models.js"
+const MODEL = CLAUDE_MODELS.sonnet.id
+const INPUT_COST_PER_MILLION = CLAUDE_MODELS.sonnet.inputCostPerMillion
+```
+
+Model IDs are plain strings that only the Anthropic API validates, and only at
+request time. A retired ID passes `tsc`, lint, tests, and deploy — then 404s in
+production on whichever path runs first. In August 2026 `claude-sonnet-4-20250514`
+was retired while six files each held their own copy; it surfaced as a 404 during
+biography enrichment.
+
+Rules:
+- **Prefer undated aliases** (`claude-sonnet-5`) over dated pins (`claude-sonnet-4-20250514`). Dated pins are what expire.
+- **Keep pricing with the ID.** Cost constants feed `costLimits.maxCostPerActor`, which gates the pipelines. A model swap without a pricing update silently corrupts the budget guard.
+- **Don't assert the literal in tests.** `expect(MODEL).toBe("claude-sonnet-5")` only restates the constant and makes the next migration a multi-file change. Assert against `CLAUDE_MODELS.<tier>.id` instead.
+- **When a model retires**, add its ID to `RETIRED_MODEL_IDS` in `claude-models.test.ts` so any lingering reference fails the build.
+
+Verify every ID in the registry is still live:
+
+```bash
+curl -s https://api.anthropic.com/v1/models \
+  -H "x-api-key: $ANTHROPIC_API_KEY" -H "anthropic-version: 2023-06-01" | jq -r '.data[].id'
+```
+
 ## Type Safety
 
 - **Database JSON columns**: `pg` auto-parses JSON — type as the parsed type (`MyType[]`), not `string`

--- a/server/newrelic.cjs
+++ b/server/newrelic.cjs
@@ -124,9 +124,20 @@ exports.config = {
   // APM datastore spans to the infrastructure PostgreSQL/Redis integrations.
   // Without this, NR shows databases as "uninstrumented" because the APM
   // agent reports host=<container-id> while infra reports host=deadonfilm-server.
-  process_host: {
-    display_name: process.env.NEW_RELIC_PROCESS_HOST_DISPLAY_NAME || undefined
-  },
+  //
+  // The key is spread in conditionally rather than set to `undefined`. An
+  // explicit `display_name: undefined` is NOT the same as omitting it: the
+  // agent treats the key as present and getDisplayHost() calls
+  // Buffer.from(undefined), throwing ERR_INVALID_ARG_TYPE and killing the
+  // process. That crashes every local run and CI test where
+  // NEW_RELIC_PROCESS_HOST_DISPLAY_NAME is unset.
+  ...(process.env.NEW_RELIC_PROCESS_HOST_DISPLAY_NAME
+    ? {
+        process_host: {
+          display_name: process.env.NEW_RELIC_PROCESS_HOST_DISPLAY_NAME
+        }
+      }
+    : {}),
 
   // Code-level metrics (shows function-level performance)
   code_level_metrics: {

--- a/server/scripts/backfill-birthdays.ts
+++ b/server/scripts/backfill-birthdays.ts
@@ -11,13 +11,15 @@ import { Command } from "commander"
 import { getPool } from "../src/lib/db.js"
 import { calculateYearsLost } from "../src/lib/mortality-stats.js"
 import Anthropic from "@anthropic-ai/sdk"
+import { CLAUDE_MODELS } from "../src/lib/claude-models.js"
+import { extractClaudeText } from "../src/lib/shared/claude-json.js"
 
 const anthropic = new Anthropic()
 
 async function lookupBirthday(name: string, deathday: string): Promise<string | null> {
   try {
     const response = await anthropic.messages.create({
-      model: "claude-sonnet-4-20250514",
+      model: CLAUDE_MODELS.sonnet.id,
       max_tokens: 100,
       messages: [
         {
@@ -30,8 +32,7 @@ Do not include any other text.`,
       ],
     })
 
-    const text =
-      response.content[0].type === "text" ? response.content[0].text.trim().toLowerCase() : ""
+    const text = extractClaudeText(response).trim().toLowerCase()
 
     // Validate it looks like a date
     if (text === "unknown" || text.includes("unknown")) {

--- a/server/scripts/backfill-cause-manner.ts
+++ b/server/scripts/backfill-cause-manner.ts
@@ -17,6 +17,8 @@
 import "dotenv/config"
 import { Command, InvalidArgumentError } from "commander"
 import Anthropic from "@anthropic-ai/sdk"
+import { CLAUDE_MODELS } from "../src/lib/claude-models.js"
+import { extractClaudeText } from "../src/lib/shared/claude-json.js"
 import { getPool } from "../src/lib/db/pool"
 import { getClaudeRateLimiter } from "../src/lib/claude"
 import { recordCliEvent } from "../src/lib/newrelic-cli.js"
@@ -252,17 +254,17 @@ ${causes.map((c, i) => `${i + 1}. "${c}"`).join("\n")}
 Respond with JSON array: [{"cause": "exact input", "manner": "classification"}]`
 
   const response = await client.messages.create({
-    model: "claude-sonnet-4-5-20250929",
+    model: CLAUDE_MODELS.sonnet.id,
     max_tokens: 4096,
     messages: [{ role: "user", content: prompt }],
   })
 
-  const content = response.content[0]
-  if (content.type !== "text") {
-    throw new Error("Unexpected response type from Claude")
+  const responseText = extractClaudeText(response)
+  if (!responseText) {
+    throw new Error("No text block in Claude response")
   }
 
-  let jsonText = content.text.trim()
+  let jsonText = responseText.trim()
   if (jsonText.startsWith("```")) {
     jsonText = jsonText.replace(/^```(?:json)?\s*\n?/, "").replace(/\n?```\s*$/, "")
   }
@@ -434,7 +436,7 @@ async function main(options: { dryRun: boolean; batchSize: number }) {
 
         recordCliEvent("CauseMannerClassification", {
           batchSize: batch.length,
-          model: "claude-sonnet-4-5-20250929",
+          model: CLAUDE_MODELS.sonnet.id,
           success: true,
           inputTokens: usage.inputTokens,
           outputTokens: usage.outputTokens,
@@ -462,7 +464,7 @@ async function main(options: { dryRun: boolean; batchSize: number }) {
         console.error(`  Error processing batch:`, error)
         recordCliEvent("CauseMannerClassification", {
           batchSize: batch.length,
-          model: "claude-sonnet-4-5-20250929",
+          model: CLAUDE_MODELS.sonnet.id,
           success: false,
           error: error instanceof Error ? error.message.substring(0, 1000) : "Unknown error",
         })

--- a/server/scripts/backfill-cause-normalizations.ts
+++ b/server/scripts/backfill-cause-normalizations.ts
@@ -14,6 +14,8 @@
 import "dotenv/config"
 import { Command, InvalidArgumentError } from "commander"
 import Anthropic from "@anthropic-ai/sdk"
+import { CLAUDE_MODELS } from "../src/lib/claude-models.js"
+import { extractClaudeText } from "../src/lib/shared/claude-json.js"
 import { getPool } from "../src/lib/db/pool"
 import { getClaudeRateLimiter } from "../src/lib/claude"
 import { recordCliEvent } from "../src/lib/newrelic-cli.js"
@@ -62,19 +64,19 @@ ${causes.map((c, i) => `${i + 1}. "${c}"`).join("\n")}
 Respond with JSON array: [{"original": "exact input", "normalized": "your normalized version"}]`
 
   const response = await client.messages.create({
-    model: "claude-opus-4-5-20251101",
+    model: CLAUDE_MODELS.opus.id,
     max_tokens: 4096,
     messages: [{ role: "user", content: prompt }],
   })
 
-  const content = response.content[0]
-  if (content.type !== "text") {
-    throw new Error("Unexpected response type from Claude")
+  const responseText = extractClaudeText(response)
+  if (!responseText) {
+    throw new Error("No text block in Claude response")
   }
 
   try {
     // Strip markdown code blocks if present
-    let jsonText = content.text.trim()
+    let jsonText = responseText.trim()
     if (jsonText.startsWith("```")) {
       jsonText = jsonText.replace(/^```(?:json)?\s*\n?/, "").replace(/\n?```\s*$/, "")
     }
@@ -94,7 +96,7 @@ Respond with JSON array: [{"original": "exact input", "normalized": "your normal
       },
     }
   } catch (e) {
-    console.error("Failed to parse Claude response:", content.text)
+    console.error("Failed to parse Claude response:", responseText)
     throw e
   }
 }
@@ -167,7 +169,7 @@ async function main(options: { dryRun: boolean; batchSize: number }) {
         batchSize: batch.length,
         causesInput: batch.join(" | ").substring(0, 4000),
         normalizationsOutput,
-        model: "claude-opus-4-5-20251101",
+        model: CLAUDE_MODELS.opus.id,
         success: true,
         inputTokens: result.usage.inputTokens,
         outputTokens: result.usage.outputTokens,
@@ -222,7 +224,7 @@ async function main(options: { dryRun: boolean; batchSize: number }) {
       // Record failed New Relic event
       recordCliEvent("CauseOfDeathNormalization", {
         batchSize: batch.length,
-        model: "claude-opus-4-5-20251101",
+        model: CLAUDE_MODELS.opus.id,
         success: false,
         error: error instanceof Error ? error.message.substring(0, 1000) : "Unknown error",
       })

--- a/server/scripts/backfill-shows-full.ts
+++ b/server/scripts/backfill-shows-full.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env tsx
+import "dotenv/config" // MUST precede newrelic: newrelic.cjs reads NEW_RELIC_LICENSE_KEY at import time
 import newrelic from "newrelic"
 /**
  * All-in-one TV show backfill script.
@@ -26,7 +27,6 @@ import newrelic from "newrelic"
  *   npm run backfill:shows:full -- --shows 987 --source imdb --include-cast
  */
 
-import "dotenv/config"
 import path from "path"
 import { Command, InvalidArgumentError } from "commander"
 import {

--- a/server/scripts/backfill-tmdb-batch.ts
+++ b/server/scripts/backfill-tmdb-batch.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env tsx
+import "dotenv/config" // MUST precede newrelic: newrelic.cjs reads NEW_RELIC_LICENSE_KEY at import time
 import newrelic from "newrelic"
 /**
  * Batch backfill TMDB sync in configurable batches with resumption
@@ -18,7 +19,6 @@ import newrelic from "newrelic"
  *   npm run backfill:tmdb -- --start-date 2026-01-01 --end-date 2026-01-21 --reset
  */
 
-import "dotenv/config"
 import { Command, InvalidArgumentError } from "commander"
 import { promises as fs } from "fs"
 import * as readline from "readline"

--- a/server/scripts/backfill-violent-deaths.ts
+++ b/server/scripts/backfill-violent-deaths.ts
@@ -18,6 +18,8 @@ import "dotenv/config"
 import { Command } from "commander"
 import pg from "pg"
 import Anthropic from "@anthropic-ai/sdk"
+import { CLAUDE_MODELS } from "../src/lib/claude-models.js"
+import { extractClaudeText } from "../src/lib/shared/claude-json.js"
 
 const { Pool } = pg
 
@@ -119,13 +121,12 @@ Do not include any other text.`
 
   try {
     const message = await anthropic.messages.create({
-      model: "claude-3-haiku-20240307",
+      model: CLAUDE_MODELS.haiku.id,
       max_tokens: 10,
       messages: [{ role: "user", content: prompt }],
     })
 
-    const response =
-      message.content[0].type === "text" ? message.content[0].text.trim().toLowerCase() : ""
+    const response = extractClaudeText(message).trim().toLowerCase()
 
     if (response === "yes") return true
     if (response === "no") return false

--- a/server/scripts/run-cause-of-death-batch.ts
+++ b/server/scripts/run-cause-of-death-batch.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env tsx
+import "dotenv/config" // MUST precede newrelic: newrelic.cjs reads NEW_RELIC_LICENSE_KEY at import time
 import newrelic from "newrelic"
 /**
  * Continuous runner for cause of death batch processing.
@@ -20,7 +21,6 @@ import newrelic from "newrelic"
  *   --all                 Process ALL deceased actors (not just those missing cause)
  */
 
-import "dotenv/config"
 import Anthropic from "@anthropic-ai/sdk"
 import { Command } from "commander"
 import { MODEL_ID } from "../src/lib/claude-batch/constants.js"

--- a/server/scripts/run-cause-of-death-batch.ts
+++ b/server/scripts/run-cause-of-death-batch.ts
@@ -23,6 +23,7 @@ import newrelic from "newrelic"
 import "dotenv/config"
 import Anthropic from "@anthropic-ai/sdk"
 import { Command } from "commander"
+import { MODEL_ID } from "../src/lib/claude-batch/constants.js"
 import * as readline from "readline"
 import { getPool, resetPool } from "../src/lib/db.js"
 import { toSentenceCase } from "../src/lib/text-utils.js"
@@ -38,6 +39,7 @@ import {
   type Checkpoint,
 } from "./backfill-cause-of-death-batch.js"
 import { jsonrepair } from "jsonrepair"
+import { extractClaudeText } from "../src/lib/shared/claude-json.js"
 
 // Initialize New Relic for monitoring
 
@@ -250,7 +252,7 @@ async function run(options: {
       const requests = result.rows.map((actor) => ({
         custom_id: `actor-${actor.id}`,
         params: {
-          model: "claude-opus-4-5-20251101",
+          model: MODEL_ID,
           max_tokens: 300,
           messages: [
             {
@@ -534,7 +536,7 @@ export async function processResults(
 
       if (result.result.type === "succeeded") {
         const message = result.result.message
-        const responseText = message.content[0].type === "text" ? message.content[0].text : ""
+        const responseText = extractClaudeText(message)
 
         try {
           const jsonText = stripMarkdownCodeFences(responseText)

--- a/server/scripts/sync-tmdb-changes.ts
+++ b/server/scripts/sync-tmdb-changes.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env tsx
+import "dotenv/config" // MUST precede newrelic: newrelic.cjs reads NEW_RELIC_LICENSE_KEY at import time
 import newrelic from "newrelic"
 /**
  * Sync script to detect newly deceased actors, movie changes, and new show episodes from TMDB.
@@ -21,7 +22,6 @@ import newrelic from "newrelic"
  *   npm run sync:tmdb -- --shows-only                   # Only sync active TV show episodes
  */
 
-import "dotenv/config"
 import { Command, InvalidArgumentError } from "commander"
 import { getPool } from "../src/lib/db.js"
 import {

--- a/server/src/lib/biography-sources/claude-cleanup.test.ts
+++ b/server/src/lib/biography-sources/claude-cleanup.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest"
 import type { ActorForBiography, RawBiographySourceData } from "./types.js"
 import { BiographySourceType } from "./types.js"
+import { CLAUDE_MODELS } from "../claude-models.js"
 
 // Shared mock create function accessible from all tests
 const mockCreate = vi.fn()
@@ -112,15 +113,14 @@ function makeMockApiResponse(
   jsonData: Record<string, unknown>,
   tokenOverrides?: { input?: number; output?: number }
 ) {
-  // Strip leading "{" to match assistant prefill behavior —
-  // the API call uses { role: "assistant", content: "{" } so Claude's
-  // response continues from after the opening brace
-  const fullJson = JSON.stringify(jsonData)
+  // Full JSON including the opening brace. Assistant prefill was removed
+  // because models from the 4.6 generation onward reject it with a 400, so
+  // the model now returns a complete object.
   return {
     content: [
       {
         type: "text" as const,
-        text: fullJson.slice(1),
+        text: JSON.stringify(jsonData),
       },
     ],
     usage: {
@@ -422,9 +422,9 @@ describe("claude-cleanup (biography)", () => {
 
       const result = await synthesizeBiography(mockActor, mockSources)
 
-      expect(result.model).toBe("claude-sonnet-4-20250514")
+      expect(result.model).toBe(CLAUDE_MODELS.sonnet.id)
       expect(mockCreate).toHaveBeenCalledWith(
-        expect.objectContaining({ model: "claude-sonnet-4-20250514" })
+        expect.objectContaining({ model: CLAUDE_MODELS.sonnet.id })
       )
     })
 
@@ -432,12 +432,12 @@ describe("claude-cleanup (biography)", () => {
       mockCreate.mockResolvedValue(makeMockApiResponse(makeValidClaudeResponse()))
 
       const result = await synthesizeBiography(mockActor, mockSources, {
-        model: "claude-opus-4-20250514",
+        model: CLAUDE_MODELS.opus.id,
       })
 
-      expect(result.model).toBe("claude-opus-4-20250514")
+      expect(result.model).toBe(CLAUDE_MODELS.opus.id)
       expect(mockCreate).toHaveBeenCalledWith(
-        expect.objectContaining({ model: "claude-opus-4-20250514" })
+        expect.objectContaining({ model: CLAUDE_MODELS.opus.id })
       )
     })
 
@@ -455,9 +455,8 @@ describe("claude-cleanup (biography)", () => {
 
     it("strips markdown fences from response", async () => {
       const validResponse = makeValidClaudeResponse()
-      // With assistant prefill "{", Claude's fenced response omits the leading brace
-      const jsonWithoutBrace = JSON.stringify(validResponse).slice(1)
-      mockCreate.mockResolvedValue(makeMockApiResponseRaw("```json\n" + jsonWithoutBrace + "\n```"))
+      const json = JSON.stringify(validResponse)
+      mockCreate.mockResolvedValue(makeMockApiResponseRaw("```json\n" + json + "\n```"))
 
       const result = await synthesizeBiography(mockActor, mockSources)
 

--- a/server/src/lib/biography-sources/claude-cleanup.ts
+++ b/server/src/lib/biography-sources/claude-cleanup.ts
@@ -15,12 +15,13 @@ import { callClaudeForJson } from "../shared/claude-json.js"
 import { sanitizeSourceText } from "../shared/sanitize-source-text.js"
 import { getPool } from "../db/pool.js"
 import { saveRejectedFactors } from "../rejected-factors.js"
+import { CLAUDE_MODELS } from "../claude-models.js"
 
 // Sonnet pricing (per million tokens)
-const INPUT_COST_PER_MILLION = 3
-const OUTPUT_COST_PER_MILLION = 15
+const INPUT_COST_PER_MILLION = CLAUDE_MODELS.sonnet.inputCostPerMillion
+const OUTPUT_COST_PER_MILLION = CLAUDE_MODELS.sonnet.outputCostPerMillion
 
-const DEFAULT_MODEL = "claude-sonnet-4-20250514"
+const DEFAULT_MODEL = CLAUDE_MODELS.sonnet.id
 const MAX_TOKENS = 4096
 const MAX_SOURCE_CHARS = 60_000
 

--- a/server/src/lib/biography-sources/content-cleaner.ts
+++ b/server/src/lib/biography-sources/content-cleaner.ts
@@ -22,6 +22,7 @@ import {
 import { stripMarkdownCodeFences } from "../claude-batch/response-parser.js"
 import { extractArticleContent } from "../shared/readability-extract.js"
 import type { CleanedContent } from "./types.js"
+import { CLAUDE_MODELS } from "../claude-models.js"
 
 // ============================================================================
 // Types
@@ -750,9 +751,9 @@ export function mechanicalPreClean(html: string, url?: string): MechanicalCleanR
 // ============================================================================
 
 /** Haiku 4.5 pricing per million tokens */
-const HAIKU_INPUT_COST_PER_MILLION = 1.0
-const HAIKU_OUTPUT_COST_PER_MILLION = 5.0
-const HAIKU_MODEL = "claude-haiku-4-5-20251001"
+const HAIKU_INPUT_COST_PER_MILLION = CLAUDE_MODELS.haiku.inputCostPerMillion
+const HAIKU_OUTPUT_COST_PER_MILLION = CLAUDE_MODELS.haiku.outputCostPerMillion
+const HAIKU_MODEL = CLAUDE_MODELS.haiku.id
 const HAIKU_MAX_TOKENS = 2000
 
 /**

--- a/server/src/lib/biography-sources/debriefer/adapter.ts
+++ b/server/src/lib/biography-sources/debriefer/adapter.ts
@@ -69,10 +69,6 @@ import type {
 } from "../types.js"
 import { synthesizeBiography, type BiographySynthesisResult } from "../claude-cleanup.js"
 
-// Logging
-import { logger } from "../../logger.js"
-const log = logger.child({ name: "bio-debriefer-adapter" })
-
 // Page fetching infrastructure for link following
 import { createBrowserFetchPage } from "@debriefer/browser"
 import { getCaptchaSolverConfig } from "../../shared/captcha-config.js"

--- a/server/src/lib/biography-sources/integration.test.ts
+++ b/server/src/lib/biography-sources/integration.test.ts
@@ -78,6 +78,7 @@ import { invalidateActorCache } from "../cache.js"
 import type { ActorForBiography, BiographyData, BiographySourceEntry } from "./types.js"
 import { BiographySourceType } from "./types.js"
 import wtf from "wtf_wikipedia"
+import { CLAUDE_MODELS } from "../claude-models.js"
 
 const mockWtfFetch = vi.mocked(wtf.fetch)
 
@@ -221,7 +222,7 @@ const CLAUDE_SYNTHESIS_RESPONSE = {
   content: [
     {
       type: "text" as const,
-      text: JSON.stringify(CLAUDE_SYNTHESIS_JSON).slice(1),
+      text: JSON.stringify(CLAUDE_SYNTHESIS_JSON),
     },
   ],
   usage: {
@@ -501,11 +502,12 @@ describe("Biography Enrichment Integration Test", () => {
       // -- Verify Claude synthesis was called --
       expect(anthropicMockCreate).toHaveBeenCalledTimes(1)
       const synthesisCallArgs = anthropicMockCreate.mock.calls[0][0]
-      expect(synthesisCallArgs.model).toBe("claude-sonnet-4-20250514")
+      expect(synthesisCallArgs.model).toBe(CLAUDE_MODELS.sonnet.id)
       expect(synthesisCallArgs.max_tokens).toBe(4096)
-      expect(synthesisCallArgs.messages).toHaveLength(2)
+      // Single user message — assistant prefill was removed because models from
+      // the 4.6 generation onward reject it with a 400.
+      expect(synthesisCallArgs.messages).toHaveLength(1)
       expect(synthesisCallArgs.messages[0].role).toBe("user")
-      expect(synthesisCallArgs.messages[1]).toEqual({ role: "assistant", content: "{" })
       // Prompt should contain actor name and source material
       expect(synthesisCallArgs.messages[0].content).toContain("John Wayne")
 
@@ -641,7 +643,7 @@ describe("Biography Enrichment Integration Test", () => {
         has_substantive_content: true,
       })
       anthropicMockCreate.mockResolvedValue({
-        content: [{ type: "text" as const, text: factorsJson.slice(1) }],
+        content: [{ type: "text" as const, text: factorsJson }],
         usage: { input_tokens: 1000, output_tokens: 400 },
       })
 

--- a/server/src/lib/biography-sources/orchestrator.test.ts
+++ b/server/src/lib/biography-sources/orchestrator.test.ts
@@ -232,6 +232,7 @@ import type { BiographyLookupResult } from "./base-source.js"
 import { getCachedQueriesForActor } from "../death-sources/cache.js"
 import type { CachedQueryResult } from "../death-sources/cache.js"
 import type { ReliabilityTier } from "../death-sources/types.js"
+import { CLAUDE_MODELS } from "../claude-models.js"
 
 // ============================================================================
 // Test Fixtures
@@ -347,7 +348,7 @@ function createSynthesisResult(
           }
         : null,
     costUsd: overrides?.costUsd ?? 0.01,
-    model: "claude-sonnet-4-20250514",
+    model: CLAUDE_MODELS.sonnet.id,
     inputTokens: 1000,
     outputTokens: 500,
     error: overrides?.error,
@@ -723,7 +724,7 @@ describe("BiographyEnrichmentOrchestrator", () => {
           books: false,
           ai: false,
         },
-        synthesisModel: "claude-sonnet-4-20250514",
+        synthesisModel: CLAUDE_MODELS.sonnet.id,
       })
 
       const wikidataMock = getMock("Wikidata")
@@ -740,7 +741,7 @@ describe("BiographyEnrichmentOrchestrator", () => {
       expect(synthesizeBiography).toHaveBeenCalledWith(
         testActor,
         expect.arrayContaining([expect.objectContaining({ sourceName: "Wikidata" })]),
-        { model: "claude-sonnet-4-20250514" }
+        { model: CLAUDE_MODELS.sonnet.id }
       )
       expect(result.data).not.toBeNull()
       expect(result.data!.narrative).toBe("Full narrative")

--- a/server/src/lib/biography-sources/surprise-discovery/boring-filter.ts
+++ b/server/src/lib/biography-sources/surprise-discovery/boring-filter.ts
@@ -143,14 +143,6 @@ function isCostarMatch(term: string, context: BoringFilterContext): boolean {
 }
 
 /**
- * Returns true if the term (longer than 3 chars) appears in the bio text.
- */
-function isInBio(term: string, bioText: string): boolean {
-  if (term.length <= 3) return false
-  return bioText.toLowerCase().includes(term.toLowerCase())
-}
-
-/**
  * Remove subset terms — if term A is a strict prefix of term B (followed by
  * a space or apostrophe), drop term A and keep term B.
  */

--- a/server/src/lib/biography-sources/surprise-discovery/incongruity-scorer.test.ts
+++ b/server/src/lib/biography-sources/surprise-discovery/incongruity-scorer.test.ts
@@ -30,6 +30,7 @@ import {
   parseHaikuResponse,
 } from "./incongruity-scorer.js"
 import type { AutocompleteSuggestion } from "./types.js"
+import { CLAUDE_MODELS } from "../../claude-models.js"
 
 function makeSuggestion(term: string): AutocompleteSuggestion {
   return {
@@ -74,7 +75,7 @@ describe("scoreIncongruity", () => {
     expect(mockCreate).toHaveBeenCalledOnce()
     expect(mockCreate).toHaveBeenCalledWith(
       expect.objectContaining({
-        model: "claude-haiku-4-5-20251001",
+        model: CLAUDE_MODELS.haiku.id,
         max_tokens: expect.any(Number),
         messages: expect.arrayContaining([expect.objectContaining({ role: "user" })]),
       })

--- a/server/src/lib/biography-sources/surprise-discovery/incongruity-scorer.ts
+++ b/server/src/lib/biography-sources/surprise-discovery/incongruity-scorer.ts
@@ -6,7 +6,7 @@
  * candidates with cost tracking.
  *
  * Candidates are sent in batches of up to 30 per API call to minimize cost.
- * Model: claude-haiku-4-5-20251001
+ * Model: `CLAUDE_MODELS.haiku`
  * Pricing: input $1.0/M tokens, output $5.0/M tokens
  */
 
@@ -14,13 +14,14 @@ import Anthropic from "@anthropic-ai/sdk"
 import { logger } from "../../logger.js"
 import { stripMarkdownCodeFences } from "../../claude-batch/response-parser.js"
 import type { AutocompleteSuggestion, IncongruityCandidate } from "./types.js"
+import { CLAUDE_MODELS } from "../../claude-models.js"
 
-const MODEL = "claude-haiku-4-5-20251001"
+const MODEL = CLAUDE_MODELS.haiku.id
 const MAX_TOKENS = 4096
 
 // Haiku pricing per million tokens
-const INPUT_COST_PER_MILLION = 1.0
-const OUTPUT_COST_PER_MILLION = 5.0
+const INPUT_COST_PER_MILLION = CLAUDE_MODELS.haiku.inputCostPerMillion
+const OUTPUT_COST_PER_MILLION = CLAUDE_MODELS.haiku.outputCostPerMillion
 
 /** Maximum candidates per Haiku call to avoid response truncation. */
 const BATCH_SIZE = 30

--- a/server/src/lib/biography-sources/surprise-discovery/incongruity-scorer.ts
+++ b/server/src/lib/biography-sources/surprise-discovery/incongruity-scorer.ts
@@ -145,7 +145,6 @@ export async function scoreIncongruity(
   }
 
   const allTerms = suggestions.map((s) => s.term)
-  const expectedTerms = new Set(allTerms)
 
   logger.debug(
     { actorName, termCount: allTerms.length, batches: Math.ceil(allTerms.length / BATCH_SIZE) },

--- a/server/src/lib/biography-sources/surprise-discovery/integrator.test.ts
+++ b/server/src/lib/biography-sources/surprise-discovery/integrator.test.ts
@@ -31,6 +31,7 @@ import {
   parseSonnetResponse,
 } from "./integrator.js"
 import type { ResearchedAssociation } from "./types.js"
+import { CLAUDE_MODELS } from "../../claude-models.js"
 
 // ── Fixtures ──────────────────────────────────────────────────────────────────
 
@@ -324,7 +325,7 @@ describe("integrateFindings", () => {
     )
   })
 
-  it("uses the correct model (claude-sonnet-4-20250514)", async () => {
+  it("uses the Sonnet model from the shared registry", async () => {
     const findings = [makeResearchedAssociation("karate black belt")]
 
     mockCreate.mockResolvedValue(
@@ -340,7 +341,7 @@ describe("integrateFindings", () => {
     await integrateFindings(ACTOR_NAME, EXISTING_NARRATIVE, EXISTING_FACTS, findings, "append-only")
 
     expect(mockCreate).toHaveBeenCalledWith(
-      expect.objectContaining({ model: "claude-sonnet-4-20250514" })
+      expect.objectContaining({ model: CLAUDE_MODELS.sonnet.id })
     )
   })
 

--- a/server/src/lib/biography-sources/surprise-discovery/integrator.ts
+++ b/server/src/lib/biography-sources/surprise-discovery/integrator.ts
@@ -7,21 +7,21 @@
  *     become a lesser-known fact, a narrative insert, or be discarded.
  *   - "re-synthesize": Claude rewrites the full narrative incorporating findings.
  *
- * Model: claude-sonnet-4-20250514
- * Pricing: input $3/M tokens, output $15/M tokens
+ * Model and pricing come from the shared registry (`CLAUDE_MODELS.sonnet`).
  */
 
 import Anthropic from "@anthropic-ai/sdk"
 import { logger } from "../../logger.js"
 import { stripMarkdownCodeFences } from "../../claude-batch/response-parser.js"
 import type { ResearchedAssociation, IntegratedFinding } from "./types.js"
+import { CLAUDE_MODELS } from "../../claude-models.js"
 
-const MODEL = "claude-sonnet-4-20250514"
+const MODEL = CLAUDE_MODELS.sonnet.id
 const MAX_TOKENS = 2048
 
 // Sonnet pricing per million tokens
-const INPUT_COST_PER_MILLION = 3
-const OUTPUT_COST_PER_MILLION = 15
+const INPUT_COST_PER_MILLION = CLAUDE_MODELS.sonnet.inputCostPerMillion
+const OUTPUT_COST_PER_MILLION = CLAUDE_MODELS.sonnet.outputCostPerMillion
 
 /**
  * Calculates the cost in USD from token usage.

--- a/server/src/lib/biography-sources/types.ts
+++ b/server/src/lib/biography-sources/types.ts
@@ -8,6 +8,7 @@
 
 import { ReliabilityTier } from "../death-sources/types.js"
 import type { LogEntry } from "../death-sources/debriefer/lifecycle-hooks.js"
+import { CLAUDE_MODELS } from "../claude-models.js"
 
 // ============================================================================
 // Source Types
@@ -323,7 +324,8 @@ export interface BiographyEnrichmentConfig {
     haikuEnabled: boolean // Enable Haiku AI extraction (Stage 2)
     mechanicalOnly: boolean // Skip Stage 2, use mechanical only
   }
-  synthesisModel: string // default "claude-sonnet-4-20250514"
+  /** Anthropic model ID for Stage 3 synthesis (default: `CLAUDE_MODELS.sonnet.id`) */
+  synthesisModel: string
   /** Number of actors to process concurrently (default: 5, range: 1-20) */
   concurrency?: number
 }
@@ -355,5 +357,5 @@ export const DEFAULT_BIOGRAPHY_CONFIG: BiographyEnrichmentConfig = {
     haikuEnabled: true,
     mechanicalOnly: false,
   },
-  synthesisModel: "claude-sonnet-4-20250514",
+  synthesisModel: CLAUDE_MODELS.sonnet.id,
 }

--- a/server/src/lib/claude-batch/batch-operations.ts
+++ b/server/src/lib/claude-batch/batch-operations.ts
@@ -18,6 +18,7 @@ import { parseClaudeResponse } from "./response-parser.js"
 import { applyUpdate } from "./actor-updater.js"
 import { storeFailure } from "./failure-recovery.js"
 import { createEmptyCheckpoint, type Checkpoint, type ActorToProcess } from "./schemas.js"
+import { extractClaudeText } from "../shared/claude-json.js"
 
 // Re-export checkpoint utilities with default file path
 export function loadCheckpoint(filePath: string = DEFAULT_CHECKPOINT_FILE): Checkpoint | null {
@@ -308,7 +309,7 @@ export async function processResults(
 
       // Parse the response
       const message = result.result.message
-      const responseText = message.content[0].type === "text" ? message.content[0].text : ""
+      const responseText = extractClaudeText(message)
 
       try {
         // parseClaudeResponse handles markdown stripping, JSON repair, and validation

--- a/server/src/lib/claude-batch/constants.ts
+++ b/server/src/lib/claude-batch/constants.ts
@@ -3,9 +3,10 @@
  */
 
 import path from "path"
+import { CLAUDE_MODELS } from "../claude-models.js"
 
 /** Claude model ID for batch processing */
-export const MODEL_ID = "claude-opus-4-5-20251101"
+export const MODEL_ID = CLAUDE_MODELS.opus.id
 
 /** Source name for database records */
 export const SOURCE_NAME = "claude-opus-4.5-batch"

--- a/server/src/lib/claude-models.test.ts
+++ b/server/src/lib/claude-models.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from "vitest"
+import {
+  CLAUDE_MODELS,
+  CLAUDE_MODEL_IDS,
+  calculateModelCost,
+  type ClaudeModelTier,
+} from "./claude-models.js"
+
+/**
+ * Model IDs are plain strings validated only by the Anthropic API at request
+ * time, so a retired ID fails as a production 404 rather than at build time.
+ *
+ * These tests deliberately do NOT assert `id === "claude-sonnet-5"`. Restating
+ * the constant proves nothing and makes the next migration a multi-file change.
+ * Instead they assert the properties that actually protect us: that no known
+ * retired ID is in use, and that IDs are shaped the way our convention requires.
+ *
+ * Liveness against the real API is verified out-of-band:
+ *   curl -s https://api.anthropic.com/v1/models \
+ *     -H "x-api-key: $ANTHROPIC_API_KEY" -H "anthropic-version: 2023-06-01"
+ */
+
+/** Model IDs Anthropic has retired. Adding one here fails the build if still referenced. */
+const RETIRED_MODEL_IDS = [
+  "claude-sonnet-4-20250514",
+  "claude-opus-4-20250514",
+  "claude-3-haiku-20240307",
+  "claude-3-sonnet-20240229",
+  "claude-3-opus-20240229",
+  "claude-3-5-sonnet-20240620",
+  "claude-3-5-sonnet-20241022",
+]
+
+const TIERS: ClaudeModelTier[] = ["haiku", "sonnet", "opus"]
+
+describe("CLAUDE_MODELS", () => {
+  it("defines every capability tier used by the enrichment pipelines", () => {
+    expect(Object.keys(CLAUDE_MODELS).sort()).toEqual(["haiku", "opus", "sonnet"])
+  })
+
+  it.each(TIERS)("does not reference a retired model ID for tier %s", (tier) => {
+    expect(RETIRED_MODEL_IDS).not.toContain(CLAUDE_MODELS[tier].id)
+  })
+
+  it.each(TIERS)("uses a well-formed anthropic model ID for tier %s", (tier) => {
+    expect(CLAUDE_MODELS[tier].id).toMatch(/^claude-[a-z0-9-]+$/)
+  })
+
+  it.each(TIERS)("defines positive pricing for tier %s", (tier) => {
+    const spec = CLAUDE_MODELS[tier]
+    expect(spec.inputCostPerMillion).toBeGreaterThan(0)
+    expect(spec.outputCostPerMillion).toBeGreaterThan(0)
+  })
+
+  it("prices output above input for every tier", () => {
+    for (const tier of TIERS) {
+      const spec = CLAUDE_MODELS[tier]
+      expect(spec.outputCostPerMillion).toBeGreaterThan(spec.inputCostPerMillion)
+    }
+  })
+
+  it("orders tiers cheapest to most expensive: haiku < sonnet < opus", () => {
+    expect(CLAUDE_MODELS.haiku.inputCostPerMillion).toBeLessThan(
+      CLAUDE_MODELS.sonnet.inputCostPerMillion
+    )
+    expect(CLAUDE_MODELS.sonnet.inputCostPerMillion).toBeLessThan(
+      CLAUDE_MODELS.opus.inputCostPerMillion
+    )
+  })
+
+  it("assigns a distinct model to each tier", () => {
+    const ids = TIERS.map((t) => CLAUDE_MODELS[t].id)
+    expect(new Set(ids).size).toBe(ids.length)
+  })
+})
+
+describe("CLAUDE_MODEL_IDS", () => {
+  it("mirrors the ids from CLAUDE_MODELS", () => {
+    expect(CLAUDE_MODEL_IDS).toEqual({
+      haiku: CLAUDE_MODELS.haiku.id,
+      sonnet: CLAUDE_MODELS.sonnet.id,
+      opus: CLAUDE_MODELS.opus.id,
+    })
+  })
+})
+
+describe("calculateModelCost", () => {
+  it("computes cost from per-million token pricing", () => {
+    const expected =
+      (1_000_000 * CLAUDE_MODELS.sonnet.inputCostPerMillion) / 1_000_000 +
+      (500_000 * CLAUDE_MODELS.sonnet.outputCostPerMillion) / 1_000_000
+    expect(calculateModelCost("sonnet", 1_000_000, 500_000)).toBeCloseTo(expected, 10)
+  })
+
+  it("returns zero for zero usage", () => {
+    expect(calculateModelCost("opus", 0, 0)).toBe(0)
+  })
+
+  it("charges more for opus than haiku on identical usage", () => {
+    expect(calculateModelCost("opus", 10_000, 1_000)).toBeGreaterThan(
+      calculateModelCost("haiku", 10_000, 1_000)
+    )
+  })
+})

--- a/server/src/lib/claude-models.ts
+++ b/server/src/lib/claude-models.ts
@@ -1,0 +1,98 @@
+/**
+ * Single source of truth for Anthropic model IDs and their pricing.
+ *
+ * Every module that calls the Anthropic API MUST import its model ID from here
+ * rather than declaring a private `const MODEL = "claude-..."`. Model IDs are
+ * plain strings that are only validated by the API at request time, so a
+ * retired ID does not fail at build, lint, or deploy — it fails as a 404 in
+ * production on whichever code path happens to run first.
+ *
+ * That is exactly what happened in August 2026: `claude-sonnet-4-20250514` was
+ * retired while six separate files each held their own copy of the string, and
+ * the breakage surfaced as a 404 during biography enrichment.
+ *
+ * Pricing lives alongside the ID on purpose. The two are halves of the same
+ * fact, and cost figures feed `costLimits.maxCostPerActor`, which gates the
+ * enrichment pipelines. Changing a model without changing its pricing silently
+ * corrupts cost tracking and the budget guard built on top of it.
+ *
+ * To verify every ID here is still live:
+ *   curl -s https://api.anthropic.com/v1/models \
+ *     -H "x-api-key: $ANTHROPIC_API_KEY" -H "anthropic-version: 2023-06-01"
+ */
+
+/** A model tier plus the pricing used for cost tracking. */
+export interface ClaudeModelSpec {
+  /** Anthropic model ID passed as `model` in API requests. */
+  readonly id: string
+  /** USD per million input tokens. */
+  readonly inputCostPerMillion: number
+  /** USD per million output tokens. */
+  readonly outputCostPerMillion: number
+}
+
+/**
+ * Capability tiers used across the enrichment pipelines.
+ *
+ * - `haiku` — cheap, high-throughput classification and extraction
+ *   (content cleaning, incongruity scoring, Wikipedia section selection).
+ * - `sonnet` — general synthesis and reasoning
+ *   (biography synthesis, discovery integration, link following, AI helpers).
+ * - `opus` — highest-quality synthesis where output is user-facing prose
+ *   (death circumstances cleanup, Claude Batch enrichment).
+ *
+ * Prefer undated aliases (`claude-sonnet-5`) over dated pins
+ * (`claude-sonnet-4-20250514`). Dated pins are what turned a routine model
+ * retirement into a production outage.
+ */
+export const CLAUDE_MODELS = {
+  haiku: {
+    id: "claude-haiku-4-5-20251001",
+    inputCostPerMillion: 1.0,
+    outputCostPerMillion: 5.0,
+  },
+  sonnet: {
+    id: "claude-sonnet-5",
+    // NOTE: carried over from Sonnet 4. The Anthropic /v1/models endpoint does
+    // not expose pricing, so these were not re-verified during the Sonnet 5
+    // migration. Confirm against https://www.anthropic.com/pricing before
+    // relying on Sonnet cost figures for budgeting.
+    inputCostPerMillion: 3,
+    outputCostPerMillion: 15,
+  },
+  opus: {
+    id: "claude-opus-4-5-20251101",
+    inputCostPerMillion: 15,
+    outputCostPerMillion: 75,
+  },
+} as const satisfies Record<string, ClaudeModelSpec>
+
+/** Capability tier name (`"haiku" | "sonnet" | "opus"`). */
+export type ClaudeModelTier = keyof typeof CLAUDE_MODELS
+
+/** Every model ID this codebase is allowed to send to the Anthropic API. */
+export const CLAUDE_MODEL_IDS: Record<ClaudeModelTier, string> = {
+  haiku: CLAUDE_MODELS.haiku.id,
+  sonnet: CLAUDE_MODELS.sonnet.id,
+  opus: CLAUDE_MODELS.opus.id,
+}
+
+/**
+ * Calculates USD cost for a call against a given tier.
+ *
+ * @param tier - Capability tier the call was made against
+ * @param inputTokens - Input tokens consumed
+ * @param outputTokens - Output tokens produced
+ * @returns Cost in USD
+ */
+export function calculateModelCost(
+  tier: ClaudeModelTier,
+  inputTokens: number,
+  outputTokens: number
+): number {
+  const spec = CLAUDE_MODELS[tier]
+  return (
+    (inputTokens * spec.inputCostPerMillion) / 1_000_000 +
+    (outputTokens * spec.outputCostPerMillion) / 1_000_000
+  )
+}

--- a/server/src/lib/claude.ts
+++ b/server/src/lib/claude.ts
@@ -1,4 +1,6 @@
 import Anthropic from "@anthropic-ai/sdk"
+import { CLAUDE_MODEL_IDS } from "./claude-models.js"
+import { extractClaudeText } from "./shared/claude-json.js"
 
 let client: Anthropic | null = null
 
@@ -25,11 +27,7 @@ export interface ClaudeCauseVerificationResult {
 
 export type ClaudeModel = "sonnet" | "haiku" | "opus"
 
-const MODEL_IDS: Record<ClaudeModel, string> = {
-  sonnet: "claude-sonnet-4-20250514",
-  haiku: "claude-3-haiku-20240307",
-  opus: "claude-opus-4-5-20251101",
-}
+const MODEL_IDS: Record<ClaudeModel, string> = CLAUDE_MODEL_IDS
 
 // Rate limits per model (requests per minute)
 // Conservative estimates to avoid hitting limits
@@ -268,7 +266,7 @@ If unknown: {"cause": null, "details": null}`
       ],
     })
 
-    const responseText = message.content[0].type === "text" ? message.content[0].text : ""
+    const responseText = extractClaudeText(message)
 
     // Parse JSON response
     const jsonMatch = responseText.match(/\{[\s\S]*\}/)
@@ -371,7 +369,7 @@ If unknown: {"cause": null, "confidence": null, "reasoning": "No reliable inform
       ],
     })
 
-    const responseText = message.content[0].type === "text" ? message.content[0].text : ""
+    const responseText = extractClaudeText(message)
 
     const jsonMatch = responseText.match(/\{[\s\S]*\}/)
     if (!jsonMatch) {
@@ -521,7 +519,7 @@ Respond with ONLY the details text (1-2 sentences) or null. No JSON, no quotes a
       ],
     })
 
-    const responseText = message.content[0].type === "text" ? message.content[0].text.trim() : ""
+    const responseText = extractClaudeText(message).trim()
 
     // Check for null response
     if (!responseText || responseText.toLowerCase() === "null") {

--- a/server/src/lib/death-sources/ai-helpers.test.ts
+++ b/server/src/lib/death-sources/ai-helpers.test.ts
@@ -15,11 +15,12 @@ import {
   aiExtractDeathInfo,
 } from "./ai-helpers.js"
 import type { ActorForEnrichment } from "./types.js"
+import { CLAUDE_MODELS } from "../claude-models.js"
 
 describe("AI Helpers", () => {
   describe("DEFAULT_AI_HELPER_MODEL", () => {
     it("exports the default model", () => {
-      expect(DEFAULT_AI_HELPER_MODEL).toBe("claude-sonnet-4-20250514")
+      expect(DEFAULT_AI_HELPER_MODEL).toBe(CLAUDE_MODELS.sonnet.id)
     })
   })
 

--- a/server/src/lib/death-sources/ai-helpers.ts
+++ b/server/src/lib/death-sources/ai-helpers.ts
@@ -5,21 +5,22 @@
  * These functions help search sources identify the most relevant links and
  * extract death information from page content.
  *
- * Default model: claude-sonnet-4-20250514 (configurable via --ai-model flag)
+ * Default model: `CLAUDE_MODELS.sonnet` (configurable via --ai-model flag)
  */
 
 import Anthropic from "@anthropic-ai/sdk"
 import type { ActorForEnrichment, EnrichmentData } from "./types.js"
 import { getEnrichmentLogger } from "./logger.js"
 import { stripMarkdownCodeFences } from "../claude-batch/response-parser.js"
+import { CLAUDE_MODELS } from "../claude-models.js"
 
 // Default AI model for helpers (Sonnet is cost-effective for these tasks)
-export const DEFAULT_AI_HELPER_MODEL = "claude-sonnet-4-20250514"
+export const DEFAULT_AI_HELPER_MODEL = CLAUDE_MODELS.sonnet.id
 const MAX_TOKENS = 1000
 
-// Cost per million tokens (Sonnet 4 - May 2025)
-const SONNET_INPUT_COST_PER_MILLION = 3
-const SONNET_OUTPUT_COST_PER_MILLION = 15
+// Cost per million tokens
+const SONNET_INPUT_COST_PER_MILLION = CLAUDE_MODELS.sonnet.inputCostPerMillion
+const SONNET_OUTPUT_COST_PER_MILLION = CLAUDE_MODELS.sonnet.outputCostPerMillion
 
 /**
  * Search result to be ranked by AI.
@@ -70,7 +71,7 @@ function calculateCost(inputTokens: number, outputTokens: number): number {
  * @param actor - Actor to find death information for
  * @param searchResults - Search results to rank
  * @param maxLinks - Maximum number of links to return
- * @param model - AI model to use (default: claude-sonnet-4-20250514)
+ * @param model - AI model to use (default: `DEFAULT_AI_HELPER_MODEL`)
  * @returns Ranked links with scores and reasons
  */
 export async function aiSelectLinks(
@@ -184,7 +185,7 @@ Return ONLY valid JSON array, no markdown fences.`
  * @param actor - Actor to extract death information for
  * @param pageContent - Text content of the page (HTML tags already stripped)
  * @param pageUrl - URL of the page (for context)
- * @param model - AI model to use (default: claude-sonnet-4-20250514)
+ * @param model - AI model to use (default: `DEFAULT_AI_HELPER_MODEL`)
  * @returns Extracted death information
  */
 export async function aiExtractDeathInfo(

--- a/server/src/lib/death-sources/ai-providers/claude-haiku.test.ts
+++ b/server/src/lib/death-sources/ai-providers/claude-haiku.test.ts
@@ -31,6 +31,7 @@ vi.mock("@anthropic-ai/sdk", () => {
 import { ClaudeHaikuDeathSource } from "./claude-haiku.js"
 import type { ActorForEnrichment } from "../types.js"
 import { DataSourceType } from "../types.js"
+import { CLAUDE_MODELS } from "../../claude-models.js"
 
 describe("ClaudeHaikuDeathSource", () => {
   let source: ClaudeHaikuDeathSource
@@ -146,7 +147,7 @@ describe("ClaudeHaikuDeathSource", () => {
 
       expect(mockCreate).toHaveBeenCalledWith(
         expect.objectContaining({
-          model: "claude-haiku-4-5-20251001",
+          model: CLAUDE_MODELS.haiku.id,
           temperature: 0,
           max_tokens: 2000,
         })

--- a/server/src/lib/death-sources/ai-providers/claude-haiku.ts
+++ b/server/src/lib/death-sources/ai-providers/claude-haiku.ts
@@ -23,8 +23,10 @@ import {
   parseEnrichedResponse,
   type EnrichedDeathResponse,
 } from "./shared-prompt.js"
+import { CLAUDE_MODELS } from "../../claude-models.js"
+import { extractClaudeText } from "../../shared/claude-json.js"
 
-const HAIKU_MODEL = "claude-haiku-4-5-20251001"
+const HAIKU_MODEL = CLAUDE_MODELS.haiku.id
 
 /**
  * Claude Haiku death source - fast and cost-effective (~$0.0001/query).
@@ -88,7 +90,7 @@ export class ClaudeHaikuDeathSource extends BaseDataSource {
         ],
       })
 
-      const responseText = message.content[0]?.type === "text" ? message.content[0].text : ""
+      const responseText = extractClaudeText(message)
 
       const parsed = parseEnrichedResponse(responseText)
 

--- a/server/src/lib/death-sources/ai-usage-tracker.test.ts
+++ b/server/src/lib/death-sources/ai-usage-tracker.test.ts
@@ -3,6 +3,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from "vitest"
+import { CLAUDE_MODELS } from "../claude-models.js"
 import {
   recordAIUsage,
   updateUsageQuality,
@@ -33,7 +34,7 @@ describe("AI Usage Tracker", () => {
 
       const record: Omit<AIUsageRecord, "id" | "createdAt"> = {
         actorId: 123,
-        model: "claude-sonnet-4-20250514",
+        model: CLAUDE_MODELS.sonnet.id,
         operation: "link_selection",
         inputTokens: 1000,
         outputTokens: 200,
@@ -51,7 +52,7 @@ describe("AI Usage Tracker", () => {
       const [query, params] = mockPool.query.mock.calls[0]
       expect(query).toContain("INSERT INTO ai_helper_usage")
       expect(params).toContain(123) // actorId
-      expect(params).toContain("claude-sonnet-4-20250514") // model
+      expect(params).toContain(CLAUDE_MODELS.sonnet.id) // model
       expect(params).toContain("link_selection") // operation
     })
   })
@@ -136,7 +137,7 @@ describe("AI Usage Tracker", () => {
         })
 
       await getAIUsageStats(mockPool as unknown as import("pg").Pool, {
-        model: "claude-sonnet-4-20250514",
+        model: CLAUDE_MODELS.sonnet.id,
         operation: "link_selection",
       })
 
@@ -144,7 +145,7 @@ describe("AI Usage Tracker", () => {
       const [query, params] = mockPool.query.mock.calls[0]
       expect(query).toContain("model = $")
       expect(query).toContain("operation = $")
-      expect(params).toContain("claude-sonnet-4-20250514")
+      expect(params).toContain(CLAUDE_MODELS.sonnet.id)
       expect(params).toContain("link_selection")
     })
   })
@@ -154,7 +155,7 @@ describe("AI Usage Tracker", () => {
       mockPool.query.mockResolvedValue({
         rows: [
           {
-            model: "claude-sonnet-4-20250514",
+            model: CLAUDE_MODELS.sonnet.id,
             calls: "100",
             total_cost: "0.50",
             avg_latency: "1500",
@@ -175,8 +176,8 @@ describe("AI Usage Tracker", () => {
       const result = await getAIUsageByModel(mockPool as unknown as import("pg").Pool)
 
       expect(result.size).toBe(2)
-      expect(result.get("claude-sonnet-4-20250514")?.calls).toBe(100)
-      expect(result.get("claude-sonnet-4-20250514")?.avgQuality).toBe(0.8) // 80/100
+      expect(result.get(CLAUDE_MODELS.sonnet.id)?.calls).toBe(100)
+      expect(result.get(CLAUDE_MODELS.sonnet.id)?.avgQuality).toBe(0.8) // 80/100
       expect(result.get("gpt-4o-mini")?.calls).toBe(50)
       expect(result.get("gpt-4o-mini")?.avgQuality).toBe(0.7) // 35/50
     })

--- a/server/src/lib/death-sources/claude-cleanup.ts
+++ b/server/src/lib/death-sources/claude-cleanup.ts
@@ -29,8 +29,9 @@ import { getEnrichmentLogger } from "./logger.js"
 import { getPool } from "../db/pool.js"
 import { saveRejectedFactors } from "../rejected-factors.js"
 import newrelic from "newrelic"
+import { CLAUDE_MODELS } from "../claude-models.js"
 
-const MODEL_ID = "claude-opus-4-5-20251101"
+const MODEL_ID = CLAUDE_MODELS.opus.id
 const MAX_TOKENS = 3000
 /**
  * Total character budget for all source text in the cleanup prompt.
@@ -100,8 +101,8 @@ export function isViolentDeath(manner: string | null | undefined): boolean | und
 }
 
 // Cost per million tokens (Opus 4.5)
-const INPUT_COST_PER_MILLION = 15
-const OUTPUT_COST_PER_MILLION = 75
+const INPUT_COST_PER_MILLION = CLAUDE_MODELS.opus.inputCostPerMillion
+const OUTPUT_COST_PER_MILLION = CLAUDE_MODELS.opus.outputCostPerMillion
 
 /**
  * Response structure expected from Claude.

--- a/server/src/lib/death-sources/debriefer/haiku-section-selector.ts
+++ b/server/src/lib/death-sources/debriefer/haiku-section-selector.ts
@@ -13,8 +13,10 @@
 
 import Anthropic from "@anthropic-ai/sdk"
 import type { WikipediaSection, AsyncSectionFilter } from "@debriefer/sources"
+import { CLAUDE_MODELS } from "../../claude-models.js"
+import { extractClaudeText } from "../../shared/claude-json.js"
 
-const HAIKU_MODEL = "claude-haiku-4-5-20251001"
+const HAIKU_MODEL = CLAUDE_MODELS.haiku.id
 
 function buildPrompt(sectionTitles: string[], articleIntro: string): string {
   const formatted = sectionTitles.map((title, i) => `${i + 1}. ${title}`).join("\n")
@@ -98,7 +100,7 @@ export function createHaikuSectionFilter(maxSections = 10): AsyncSectionFilter {
         messages: [{ role: "user", content: prompt }],
       })
 
-      const responseText = response.content[0]?.type === "text" ? response.content[0].text : ""
+      const responseText = extractClaudeText(response)
 
       const selectedTitles = parseResponse(responseText)
       if (!selectedTitles || selectedTitles.length === 0) return sections

--- a/server/src/lib/death-sources/link-follower.ts
+++ b/server/src/lib/death-sources/link-follower.ts
@@ -35,14 +35,15 @@ import {
 import { chromium } from "playwright-core"
 
 import { consoleLog } from "./logger.js"
+import { CLAUDE_MODELS } from "../claude-models.js"
 
 // Claude model for link operations (use a cheaper model than cleanup)
-const LINK_MODEL_ID = "claude-sonnet-4-20250514"
+const LINK_MODEL_ID = CLAUDE_MODELS.sonnet.id
 const MAX_TOKENS = 1000
 
-// Cost per million tokens (Sonnet 4)
-const INPUT_COST_PER_MILLION = 3
-const OUTPUT_COST_PER_MILLION = 15
+// Cost per million tokens
+const INPUT_COST_PER_MILLION = CLAUDE_MODELS.sonnet.inputCostPerMillion
+const OUTPUT_COST_PER_MILLION = CLAUDE_MODELS.sonnet.outputCostPerMillion
 
 // Fetch timeouts and limits
 const FETCH_TIMEOUT_MS = 10000

--- a/server/src/lib/death-sources/sources/internet-archive.test.ts
+++ b/server/src/lib/death-sources/sources/internet-archive.test.ts
@@ -25,6 +25,7 @@ vi.mock("../ai-helpers.js", () => ({
 import { InternetArchiveSource } from "./internet-archive.js"
 import type { ActorForEnrichment } from "../types.js"
 import { DataSourceType } from "../types.js"
+import { CLAUDE_MODELS } from "../../claude-models.js"
 
 // Mock fetch globally
 const mockFetch = vi.fn()
@@ -312,7 +313,7 @@ describe("InternetArchiveSource", () => {
           },
         ],
         costUsd: 0.001,
-        model: "claude-sonnet-4-20250514",
+        model: CLAUDE_MODELS.sonnet.id,
         inputTokens: 100,
         outputTokens: 50,
         latencyMs: 500,
@@ -358,7 +359,7 @@ describe("InternetArchiveSource", () => {
           },
         ],
         costUsd: 0.001,
-        model: "claude-sonnet-4-20250514",
+        model: CLAUDE_MODELS.sonnet.id,
         inputTokens: 100,
         outputTokens: 50,
         latencyMs: 500,
@@ -407,7 +408,7 @@ describe("InternetArchiveSource", () => {
           },
         ],
         costUsd: 0.001,
-        model: "claude-sonnet-4-20250514",
+        model: CLAUDE_MODELS.sonnet.id,
         inputTokens: 100,
         outputTokens: 50,
         latencyMs: 500,
@@ -458,7 +459,7 @@ describe("InternetArchiveSource", () => {
           },
         ],
         costUsd: 0.001,
-        model: "claude-sonnet-4-20250514",
+        model: CLAUDE_MODELS.sonnet.id,
         inputTokens: 100,
         outputTokens: 50,
         latencyMs: 500,

--- a/server/src/lib/death-sources/wikipedia-date-extractor.test.ts
+++ b/server/src/lib/death-sources/wikipedia-date-extractor.test.ts
@@ -9,6 +9,7 @@ vi.mock("@anthropic-ai/sdk", () => ({
 }))
 
 import { extractDatesWithAI, isAIDateExtractionAvailable } from "./wikipedia-date-extractor.js"
+import { CLAUDE_MODELS } from "../claude-models.js"
 
 describe("isAIDateExtractionAvailable", () => {
   afterEach(() => {
@@ -204,7 +205,7 @@ describe("extractDatesWithAI", () => {
     expect(mockCreate).toHaveBeenCalledTimes(1)
     const callArgs = mockCreate.mock.calls[0][0]
 
-    expect(callArgs.model).toBe("claude-haiku-4-5-20251001")
+    expect(callArgs.model).toBe(CLAUDE_MODELS.haiku.id)
     expect(callArgs.max_tokens).toBe(100)
     expect(callArgs.messages[0].role).toBe("user")
     expect(callArgs.messages[0].content).toContain("John Wayne")

--- a/server/src/lib/death-sources/wikipedia-date-extractor.ts
+++ b/server/src/lib/death-sources/wikipedia-date-extractor.ts
@@ -9,8 +9,10 @@
  */
 
 import Anthropic from "@anthropic-ai/sdk"
+import { CLAUDE_MODELS } from "../claude-models.js"
+import { extractClaudeText } from "../shared/claude-json.js"
 
-const CLAUDE_HAIKU_MODEL = "claude-haiku-4-5-20251001"
+const CLAUDE_HAIKU_MODEL = CLAUDE_MODELS.haiku.id
 
 const MIN_VALID_YEAR = 1000
 const MAX_VALID_YEAR = 2100
@@ -146,7 +148,7 @@ export async function extractDatesWithAI(
       { timeout: 15_000 }
     )
 
-    const responseText = message.content[0]?.type === "text" ? message.content[0].text : ""
+    const responseText = extractClaudeText(message)
     const parsed = parseDateResponse(responseText)
 
     if (!parsed) {

--- a/server/src/lib/enrichment-version.ts
+++ b/server/src/lib/enrichment-version.ts
@@ -6,8 +6,21 @@
  * constants prevents version drift across the codebase when bumping versions.
  */
 
-/** Current death enrichment version. */
+/**
+ * Current death enrichment version.
+ *
+ * Unchanged by the Aug 2026 Sonnet 5 migration: death synthesis still runs on
+ * Opus 4.5, and the two helpers that moved to Sonnet 5 (AI link selection and
+ * AI content extraction) are disabled by default, so default-run output is
+ * byte-for-byte comparable to 5.0.0.
+ */
 export const DEATH_ENRICHMENT_VERSION = "5.0.0"
 
-/** Current biography enrichment version. */
-export const BIO_ENRICHMENT_VERSION = "7.0.0"
+/**
+ * Current biography enrichment version.
+ *
+ * 7.1.0 — Stage 3 synthesis moved from the retired `claude-sonnet-4-20250514`
+ * to `claude-sonnet-5`. Narrative output differs from 7.0.0, so the version is
+ * bumped to keep per-record provenance accurate.
+ */
+export const BIO_ENRICHMENT_VERSION = "7.1.0"

--- a/server/src/lib/run-logger.ts
+++ b/server/src/lib/run-logger.ts
@@ -54,8 +54,14 @@ export class RunLogger {
     this.log("debug", message, data, source)
   }
 
-  private log(level: string, message: string, data?: Record<string, unknown>, source?: string): void {
-    const prefix = level === "error" ? "ERROR" : level === "warn" ? "WARN" : level === "debug" ? "DEBUG" : "INFO"
+  private log(
+    level: string,
+    message: string,
+    data?: Record<string, unknown>,
+    source?: string
+  ): void {
+    const prefix =
+      level === "error" ? "ERROR" : level === "warn" ? "WARN" : level === "debug" ? "DEBUG" : "INFO"
     const dataStr = data ? ` ${JSON.stringify(data)}` : ""
     console.log(`[${this.runType}:${this.runId}] [${prefix}] ${message}${dataStr}`)
 
@@ -96,7 +102,10 @@ export class RunLogger {
         [this.runType, this.runId, timestamps, levels, messages, dataArr, sources]
       )
     } catch (err) {
-      logger.error({ err, runType: this.runType, runId: this.runId }, "[RunLogger] Failed to flush logs")
+      logger.error(
+        { err, runType: this.runType, runId: this.runId },
+        "[RunLogger] Failed to flush logs"
+      )
     }
   }
 }

--- a/server/src/lib/shared/claude-json.test.ts
+++ b/server/src/lib/shared/claude-json.test.ts
@@ -1,5 +1,21 @@
 import { describe, it, expect, vi } from "vitest"
-import { callClaudeForJson } from "./claude-json.js"
+import { callClaudeForJson, extractClaudeText } from "./claude-json.js"
+import { CLAUDE_MODELS } from "../claude-models.js"
+
+/** Mirrors a response from a model with extended thinking enabled. */
+function mockClientWithThinking(textResponse: string) {
+  return {
+    messages: {
+      create: vi.fn().mockResolvedValue({
+        content: [
+          { type: "thinking", thinking: "Let me work through the sources...", signature: "abc" },
+          { type: "text", text: textResponse },
+        ],
+        usage: { input_tokens: 100, output_tokens: 50 },
+      }),
+    },
+  } as any
+}
 
 function mockClient(textResponse: string, tokens?: { input?: number; output?: number }) {
   return {
@@ -35,10 +51,10 @@ function mockClientError(error: Error) {
 }
 
 describe("callClaudeForJson", () => {
-  const opts = { model: "claude-sonnet-4-20250514", maxTokens: 1024, prompt: "Return JSON" }
+  const opts = { model: CLAUDE_MODELS.sonnet.id, maxTokens: 1024, prompt: "Return JSON" }
 
-  it("parses valid JSON response (prefill prepends opening brace)", async () => {
-    const client = mockClient('"name": "John", "age": 30}')
+  it("parses a valid JSON response", async () => {
+    const client = mockClient('{"name": "John", "age": 30}')
     const result = await callClaudeForJson(client, opts)
 
     expect(result.data).toEqual({ name: "John", age: 30 })
@@ -47,21 +63,19 @@ describe("callClaudeForJson", () => {
     expect(result.outputTokens).toBe(50)
   })
 
-  it("sends assistant prefill in messages", async () => {
-    const client = mockClient('"ok": true}')
+  it("sends a single user message with no assistant prefill", async () => {
+    const client = mockClient('{"ok": true}')
     await callClaudeForJson(client, opts)
 
     const call = client.messages.create.mock.calls[0][0]
-    expect(call.messages).toEqual([
-      { role: "user", content: "Return JSON" },
-      { role: "assistant", content: "{" },
-    ])
-    expect(call.model).toBe("claude-sonnet-4-20250514")
+    // Models from the 4.6 generation onward reject assistant prefill with a 400.
+    expect(call.messages).toEqual([{ role: "user", content: "Return JSON" }])
+    expect(call.model).toBe(CLAUDE_MODELS.sonnet.id)
     expect(call.max_tokens).toBe(1024)
   })
 
   it("passes system parameter when provided", async () => {
-    const client = mockClient('"ok": true}')
+    const client = mockClient('{"ok": true}')
     await callClaudeForJson(client, { ...opts, system: "You are a JSON bot" })
 
     const call = client.messages.create.mock.calls[0][0]
@@ -69,7 +83,7 @@ describe("callClaudeForJson", () => {
   })
 
   it("omits system parameter when not provided", async () => {
-    const client = mockClient('"ok": true}')
+    const client = mockClient('{"ok": true}')
     await callClaudeForJson(client, opts)
 
     const call = client.messages.create.mock.calls[0][0]
@@ -77,7 +91,7 @@ describe("callClaudeForJson", () => {
   })
 
   it("strips markdown code fences before parsing", async () => {
-    const client = mockClient('```json\n"narrative": "test"}\n```')
+    const client = mockClient('```json\n{"narrative": "test"}\n```')
     const result = await callClaudeForJson(client, opts)
 
     expect(result.data).toEqual({ narrative: "test" })
@@ -85,7 +99,7 @@ describe("callClaudeForJson", () => {
   })
 
   it("repairs minor JSON issues via jsonrepair", async () => {
-    const client = mockClient('"name": "John", "age": 30,}')
+    const client = mockClient('{"name": "John", "age": 30,}')
     const result = await callClaudeForJson(client, opts)
 
     expect(result.data).toEqual({ name: "John", age: 30 })
@@ -113,12 +127,21 @@ describe("callClaudeForJson", () => {
     expect(result.outputTokens).toBe(50)
   })
 
-  it("handles response that already starts with { (Claude ignores prefill)", async () => {
-    const client = mockClient('{"name": "John", "age": 30}')
+  it("recovers the object when the model wraps it in prose", async () => {
+    const client = mockClient('Here is the biography:\n{"name": "John", "age": 30}\nLet me know!')
     const result = await callClaudeForJson(client, opts)
 
     expect(result.data).toEqual({ name: "John", age: 30 })
     expect(result.error).toBeUndefined()
+  })
+
+  it("reports a parse failure when the model returns no JSON object", async () => {
+    const client = mockClient("I could not find enough information.")
+    const result = await callClaudeForJson(client, opts)
+
+    expect(result.data).toBeNull()
+    expect(result.error).toContain("no JSON object")
+    expect(result.rawSnippet).toBe("I could not find enough information.")
   })
 
   it("returns error when API call fails", async () => {
@@ -131,11 +154,76 @@ describe("callClaudeForJson", () => {
     expect(result.outputTokens).toBe(0)
   })
 
+  it("skips a leading thinking block and parses the text block", async () => {
+    const client = mockClientWithThinking('{"narrative": "test", "ok": true}')
+    const result = await callClaudeForJson(client, opts)
+
+    expect(result.data).toEqual({ narrative: "test", ok: true })
+    expect(result.error).toBeUndefined()
+  })
+
+  it("rejects prose that jsonrepair would coerce into an array", async () => {
+    // jsonrepair turns this into ["Looking at the sources", "I can see that..."],
+    // which parses cleanly. Accepting it would write garbage as enrichment data.
+    const client = mockClient("Looking at the sources, I can see that...")
+    const result = await callClaudeForJson(client, opts)
+
+    expect(result.data).toBeNull()
+    expect(result.error).toContain("Failed to parse")
+  })
+
+  it("rejects a bare JSON array", async () => {
+    const client = mockClient('["not", "an", "object"]')
+    const result = await callClaudeForJson(client, opts)
+
+    expect(result.data).toBeNull()
+    // No `{` at all, so this is caught by extractJsonObject before the shape guard.
+    expect(result.error).toContain("no JSON object")
+  })
+
+  it("rejects an array of objects rather than silently taking the first element", async () => {
+    // Brace-scanning slices `{"name": "John"}, {"name": "Jane"}`, which is not a
+    // single valid object. Rejecting is correct: quietly returning the first
+    // element would drop data and misrepresent what the model actually produced.
+    const client = mockClient('[{"name": "John"}, {"name": "Jane"}]')
+    const result = await callClaudeForJson(client, opts)
+
+    expect(result.data).toBeNull()
+    expect(result.error).toContain("Failed to parse")
+  })
+
   it("returns token counts from response usage", async () => {
-    const client = mockClient('"ok": true}', { input: 3000, output: 1200 })
+    const client = mockClient('{"ok": true}', { input: 3000, output: 1200 })
     const result = await callClaudeForJson(client, opts)
 
     expect(result.inputTokens).toBe(3000)
     expect(result.outputTokens).toBe(1200)
+  })
+})
+
+describe("extractClaudeText", () => {
+  it("returns the text block when it is the only block", () => {
+    const msg = { content: [{ type: "text", text: "hello" }] } as any
+    expect(extractClaudeText(msg)).toBe("hello")
+  })
+
+  it("skips a leading thinking block", () => {
+    const msg = {
+      content: [
+        { type: "thinking", thinking: "reasoning...", signature: "sig" },
+        { type: "text", text: "the answer" },
+      ],
+    } as any
+    expect(extractClaudeText(msg)).toBe("the answer")
+  })
+
+  it("returns an empty string when there is no text block", () => {
+    const msg = { content: [{ type: "thinking", thinking: "...", signature: "s" }] } as any
+    expect(extractClaudeText(msg)).toBe("")
+  })
+
+  it("returns an empty string when content is missing or malformed", () => {
+    expect(extractClaudeText({} as any)).toBe("")
+    expect(extractClaudeText({ content: null } as any)).toBe("")
   })
 })

--- a/server/src/lib/shared/claude-json.ts
+++ b/server/src/lib/shared/claude-json.ts
@@ -1,9 +1,9 @@
 /**
  * Shared helper for calling Claude and parsing JSON responses.
  *
- * Handles the full pipeline: API call with assistant prefill, text extraction,
- * markdown fence stripping, jsonrepair, and JSON.parse. Used by both biography
- * and death enrichment synthesis.
+ * Handles the full pipeline: API call, text extraction, markdown fence
+ * stripping, jsonrepair, and JSON.parse. Used by both biography and death
+ * enrichment synthesis.
  *
  * Never throws — returns { data: null, error } on failure.
  */
@@ -11,6 +11,51 @@
 import type Anthropic from "@anthropic-ai/sdk"
 import { stripMarkdownCodeFences } from "../claude-batch/response-parser.js"
 import { jsonrepair } from "jsonrepair"
+
+/**
+ * Extracts the assistant's text from a Claude response.
+ *
+ * ALWAYS use this instead of `message.content[0].text`. Models with extended
+ * thinking emit a `thinking` block first, so `content[0]` is not the text block
+ * and index-based access silently yields an empty string rather than an error.
+ * Scanning for the first `text` block behaves identically on models that emit
+ * no thinking block, so this is safe across every model generation.
+ *
+ * @param message - Response from `client.messages.create()`
+ * @returns The first text block's content, or `""` if the response has none
+ */
+export function extractClaudeText(message: Anthropic.Message): string {
+  const blocks = Array.isArray(message.content) ? message.content : []
+  const textBlock = blocks.find((block) => block.type === "text")
+  return textBlock && textBlock.type === "text" ? textBlock.text : ""
+}
+
+/**
+ * Isolates the JSON object from a model response that may be wrapped in prose.
+ *
+ * Prefill used to guarantee the response began mid-object, so the old parser
+ * could assume a leading `{`. Without prefill the model occasionally frames the
+ * object ("Here is the biography:\n{...}\nLet me know if..."), and `jsonrepair`
+ * cannot recover from leading prose — it needs an object to start with.
+ *
+ * Returns null when the text contains no object at all. That case MUST be
+ * treated as a failure rather than handed to `jsonrepair`: given prose,
+ * jsonrepair happily coerces "Looking at the sources, I can see that..." into
+ * the array `["Looking at the sources", "I can see that..."]`, which parses
+ * successfully and would be written to the database as enrichment output.
+ * A silent bad parse is worse than a loud failure.
+ *
+ * @param text - Response text with markdown fences already stripped
+ * @returns Substring to hand to `jsonrepair`, or null if no object is present
+ */
+function extractJsonObject(text: string): string | null {
+  const start = text.indexOf("{")
+  const end = text.lastIndexOf("}")
+  if (start === -1 || end === -1 || end < start) {
+    return null
+  }
+  return text.slice(start, end + 1)
+}
 
 export interface ClaudeJsonResult<T> {
   data: T | null
@@ -32,16 +77,19 @@ export async function callClaudeForJson<T = Record<string, unknown>>(
 ): Promise<ClaudeJsonResult<T>> {
   const { model, maxTokens, prompt, system } = options
 
-  // Call Claude with assistant prefill to force JSON output
+  // NOTE: this previously sent an assistant prefill (`{ role: "assistant",
+  // content: "{" }`) to force JSON output. Models from the 4.6 generation
+  // onward reject prefill with:
+  //   400 "This model does not support assistant message prefill.
+  //        The conversation must end with a user message."
+  // JSON is now coerced by the prompt and recovered by extractJsonObject()
+  // below, which is generation-agnostic.
   let response: Anthropic.Message
   try {
     response = await client.messages.create({
       model,
       max_tokens: maxTokens,
-      messages: [
-        { role: "user", content: prompt },
-        { role: "assistant", content: "{" },
-      ],
+      messages: [{ role: "user", content: prompt }],
       ...(system !== undefined && { system }),
     })
   } catch (error) {
@@ -57,10 +105,9 @@ export async function callClaudeForJson<T = Record<string, unknown>>(
   const inputTokens = response.usage?.input_tokens ?? 0
   const outputTokens = response.usage?.output_tokens ?? 0
 
-  // Extract text block — Array.isArray guard for never-throws contract
-  const contentBlocks = Array.isArray(response.content) ? response.content : []
-  const textBlock = contentBlocks.find((block) => block.type === "text")
-  if (!textBlock || textBlock.type !== "text") {
+  // Skips any leading thinking block — see extractClaudeText()
+  const rawText = extractClaudeText(response)
+  if (!rawText) {
     return {
       data: null,
       inputTokens,
@@ -69,20 +116,29 @@ export async function callClaudeForJson<T = Record<string, unknown>>(
     }
   }
 
-  // Parse JSON: strip fences, restore { from prefill when needed, repair, parse
+  // Parse JSON: strip fences, isolate the object, repair, parse
   try {
-    const stripped = stripMarkdownCodeFences(textBlock.text.trim())
-    const withBrace = stripped.startsWith("{") ? stripped : "{" + stripped
-    const repaired = jsonrepair(withBrace)
-    const parsed = JSON.parse(repaired) as T
-    return { data: parsed, inputTokens, outputTokens }
+    const stripped = stripMarkdownCodeFences(rawText.trim())
+    const objectText = extractJsonObject(stripped)
+    if (objectText === null) {
+      throw new Error("response contains no JSON object")
+    }
+    const parsed: unknown = JSON.parse(jsonrepair(objectText))
+    // Guard the shape jsonrepair produced. Callers all expect a JSON object;
+    // accepting an array or scalar here would write malformed enrichment data.
+    if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+      throw new Error(
+        `expected a JSON object, got ${Array.isArray(parsed) ? "array" : typeof parsed}`
+      )
+    }
+    return { data: parsed as T, inputTokens, outputTokens }
   } catch (error) {
     return {
       data: null,
       inputTokens,
       outputTokens,
       error: `Failed to parse Claude response as JSON: ${error instanceof Error ? error.message : "Unknown error"}`,
-      rawSnippet: textBlock.text.slice(0, 200),
+      rawSnippet: rawText.slice(0, 200),
     }
   }
 }

--- a/server/src/routes/admin/run-logs-handler.ts
+++ b/server/src/routes/admin/run-logs-handler.ts
@@ -17,7 +17,9 @@ import { logger } from "../../lib/logger.js"
  * @param runType - Discriminator for the run_logs.run_type column ("death" or "biography")
  * @returns Express route handler
  */
-export function createRunLogsHandler(runType: "death" | "biography"): (req: Request, res: Response) => Promise<void> {
+export function createRunLogsHandler(
+  runType: "death" | "biography"
+): (req: Request, res: Response) => Promise<void> {
   return async (req: Request, res: Response): Promise<void> => {
     try {
       const pool = getPool()

--- a/server/src/routes/admin/run-logs.test.ts
+++ b/server/src/routes/admin/run-logs.test.ts
@@ -22,20 +22,18 @@ describe("run logs handler", () => {
   })
 
   it("returns paginated run logs filtered by run_type and run_id", async () => {
-    mockQuery
-      .mockResolvedValueOnce({ rows: [{ total: "5" }] })
-      .mockResolvedValueOnce({
-        rows: [
-          {
-            id: 1,
-            timestamp: "2026-02-24T00:00:00Z",
-            level: "info",
-            message: "Starting enrichment",
-            data: null,
-            source: null,
-          },
-        ],
-      })
+    mockQuery.mockResolvedValueOnce({ rows: [{ total: "5" }] }).mockResolvedValueOnce({
+      rows: [
+        {
+          id: 1,
+          timestamp: "2026-02-24T00:00:00Z",
+          level: "info",
+          message: "Starting enrichment",
+          data: null,
+          source: null,
+        },
+      ],
+    })
 
     const res = await request(app).get("/run-logs?runId=42&page=1&pageSize=50")
     expect(res.status).toBe(200)
@@ -50,20 +48,18 @@ describe("run logs handler", () => {
   })
 
   it("filters by level when provided", async () => {
-    mockQuery
-      .mockResolvedValueOnce({ rows: [{ total: "1" }] })
-      .mockResolvedValueOnce({
-        rows: [
-          {
-            id: 2,
-            timestamp: "2026-02-24T00:00:00Z",
-            level: "error",
-            message: "Failed",
-            data: null,
-            source: null,
-          },
-        ],
-      })
+    mockQuery.mockResolvedValueOnce({ rows: [{ total: "1" }] }).mockResolvedValueOnce({
+      rows: [
+        {
+          id: 2,
+          timestamp: "2026-02-24T00:00:00Z",
+          level: "error",
+          message: "Failed",
+          data: null,
+          source: null,
+        },
+      ],
+    })
 
     const res = await request(app).get("/run-logs?runId=42&level=error")
     expect(res.status).toBe(200)
@@ -80,9 +76,7 @@ describe("run logs handler", () => {
   })
 
   it("ignores invalid level values", async () => {
-    mockQuery
-      .mockResolvedValueOnce({ rows: [{ total: "0" }] })
-      .mockResolvedValueOnce({ rows: [] })
+    mockQuery.mockResolvedValueOnce({ rows: [{ total: "0" }] }).mockResolvedValueOnce({ rows: [] })
 
     const res = await request(app).get("/run-logs?runId=42&level=invalid")
     expect(res.status).toBe(200)
@@ -93,9 +87,7 @@ describe("run logs handler", () => {
   })
 
   it("uses biography run_type for bio-run-logs route", async () => {
-    mockQuery
-      .mockResolvedValueOnce({ rows: [{ total: "0" }] })
-      .mockResolvedValueOnce({ rows: [] })
+    mockQuery.mockResolvedValueOnce({ rows: [{ total: "0" }] }).mockResolvedValueOnce({ rows: [] })
 
     const res = await request(app).get("/bio-run-logs?runId=10")
     expect(res.status).toBe(200)

--- a/src/pages/admin/BioEnrichmentRunDetailsPage.test.tsx
+++ b/src/pages/admin/BioEnrichmentRunDetailsPage.test.tsx
@@ -65,7 +65,7 @@ describe("BioEnrichmentRunDetailsPage", () => {
           },
         ],
         sources_succeeded: 2,
-        synthesis_model: "claude-sonnet-4-20250514",
+        synthesis_model: "claude-sonnet-5",
         processing_time_ms: 4500,
         cost_usd: "0.0350",
         source_cost_usd: "0.0000",


### PR DESCRIPTION
## Summary

Biography enrichment was failing in production with:

```
404 not_found_error: model: claude-sonnet-4-20250514
```

Anthropic retired that model. I audited **every** model ID in the codebase against the live `/v1/models` endpoint, which surfaced **three separate breakages** — only the first of which was visible.

## What was actually broken

| # | Issue | Symptom | Blast radius |
|---|-------|---------|--------------|
| 1 | `claude-sonnet-4-20250514` retired (also `claude-3-haiku-20240307`, `claude-opus-4-20250514`) | **404** | 20 sites, 6 with private copies of the string |
| 2 | Current-gen models dropped assistant prefill | **400** `does not support assistant message prefill` | `callClaudeForJson` — shared by bio **and** death synthesis |
| 3 | Current-gen models emit `thinking` as `content[0]` | **silent empty string**, no error | 13 call sites |

Issue 3 is the dangerous one: it produces empty enrichment data rather than failing.

### Live model audit

```
claude-opus-5  claude-sonnet-5  claude-fable-5  claude-opus-4-8  claude-opus-4-7
claude-sonnet-4-6  claude-opus-4-6  claude-opus-4-5-20251101
claude-haiku-4-5-20251001  claude-sonnet-4-5-20250929  claude-opus-4-1-20250805
```

### Prefill support, verified per-model

| Model | Prefill |
|---|---|
| `claude-sonnet-5`, `claude-opus-5`, `claude-opus-4-8`, `claude-sonnet-4-6`, `claude-opus-4-6` | NO |
| `claude-opus-4-5-20251101`, `claude-haiku-4-5-20251001`, `claude-sonnet-4-5-20250929` | YES |

Prefill is a dead end — it only works on the older generation, which will itself retire.

## Changes

**New `server/src/lib/claude-models.ts`** — single source of truth holding each tier's model ID *together with its pricing*. Cost constants feed `costLimits.maxCostPerActor`, which gates both pipelines, so a model swap that misses the pricing silently corrupts the budget guard.

```ts
export const CLAUDE_MODELS = {
  haiku:  { id: "claude-haiku-4-5-20251001", inputCostPerMillion: 1.0, outputCostPerMillion: 5.0 },
  sonnet: { id: "claude-sonnet-5",           inputCostPerMillion: 3,   outputCostPerMillion: 15 },
  opus:   { id: "claude-opus-4-5-20251101",  inputCostPerMillion: 15,  outputCostPerMillion: 75 },
} as const satisfies Record<string, ClaudeModelSpec>
```

- **Removed assistant prefill**; JSON recovered via brace extraction, generation-agnostic.
- **Added `extractClaudeText()`** — scans for the first `text` block. Identical behavior on models without thinking blocks, so it is safe everywhere.
- **Reject responses containing no JSON object.** Given prose, `jsonrepair` coerces `"Looking at the sources, I can see that..."` into a clean-parsing two-element array that would have been written to the database. A loud failure beats a silent bad parse.
- **Tests assert against `CLAUDE_MODELS`**, not the literal — restating the constant proved nothing and made this a multi-file change.
- **`BIO_ENRICHMENT_VERSION` to 7.1.0.** Death stays at 5.0.0: its synthesis still runs on Opus 4.5, and the two helpers that moved to Sonnet 5 are off by default, so default-run output is unchanged.
- **Documented the convention** in `.claude/rules/coding-standards.md`, incl. adding retired IDs to `RETIRED_MODEL_IDS` so stragglers fail the build.

## Test Plan

- [x] **End-to-end verification of the reported failure** — ran real `synthesizeBiography()` for Emma Stone (the exact path that 404'd) against the live API: completes on `claude-sonnet-5`, 3858 in / 2926 out tokens, returns a substantive narrative correctly focused on personal life per editorial policy
- [x] Server suite: **5731 passed**, 0 failures
- [x] Frontend suite: **2415 passed**, 0 failures
- [x] `tsc --noEmit` clean, both packages
- [x] 17 new tests for the registry; 9 new tests for thinking-block and prose-wrapping handling
- [x] Lint/format clean: eslint **0 errors** (down from 3 on `main`), `format:check` passing (3 files were failing on `main`)

## Also fixed in this PR (second commit)

Review turned up related breakage that is now fixed rather than deferred:

**New Relic config crash.** `newrelic.cjs` set `process_host.display_name: undefined` when `NEW_RELIC_PROCESS_HOST_DISPLAY_NAME` is unset. An explicit `undefined` is not the same as omitting the key — the agent treats it as present and `getDisplayHost()` calls `Buffer.from(undefined)`, throwing `ERR_INVALID_ARG_TYPE` and killing the process. This crashed **21 tests on `main`** and every CLI script run locally. Now spread in conditionally.

**APM was silently disabled in 4 scripts.** Copilot flagged import order in `run-cause-of-death-batch.ts` and was right, for a stronger reason than convention: `newrelic.cjs` reads `NEW_RELIC_LICENSE_KEY` at import time, but `import "dotenv/config"` ran *after* `import newrelic`, so the key was undefined for local runs. Verified against the real config:

```
before (newrelic first): license_key -> undefined   (APM disabled)
after  (dotenv first)  : license_key -> RESOLVED
```

Fixed in all four scripts importing both (`backfill-shows-full`, `backfill-tmdb-batch`, `run-cause-of-death-batch`, `sync-tmdb-changes`), each with a comment recording why the order matters.

**Dead code — 3 eslint errors to 0.** Unused `log` child logger in `adapter.ts`, uncalled `isInBio` in `boring-filter.ts`, and a leftover global `expectedTerms` set in `incongruity-scorer.ts` left over from the switch to per-batch validation. Also ran prettier on three files that were failing `format:check` on `main`.

Quality gates now fully clean, with no workarounds: **5731 server + 2415 frontend tests pass**, `tsc` clean both packages, `format:check` clean, eslint **0 errors** (7 remaining warnings are pre-existing `detect-unsafe-regex` in untouched files).

## Remaining open question

**Sonnet 5 pricing is carried over from Sonnet 4 and unverified** — the API exposes no pricing endpoint, so I did not invent figures. Flagged inline in `claude-models.ts`. Worth confirming against the pricing page: Sonnet 5's adaptive thinking increases output tokens, and the Emma Stone verification run cost $0.055, at the top of the documented $0.01–0.05 range.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
